### PR TITLE
feat: brochureware responsive improvements and mobile menu

### DIFF
--- a/packages/brochureware/src/components/Header.tsx
+++ b/packages/brochureware/src/components/Header.tsx
@@ -1,11 +1,12 @@
 import { Button } from "@/components/ui/button";
 import ThemeToggle from "@/components/ThemeToggle";
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { Menu } from "lucide-react";
 
 const Header = () => {
   return (
     <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-16 max-w-7xl items-center justify-between">
-        {/* Logo and Brand */}
         <a href="/" className="flex items-center space-x-3">
           <img src="/favicon.svg" alt="DarkAuth Logo" className="h-10 w-10 dark:brightness-[100]" />
           <div className="flex flex-col">
@@ -14,7 +15,6 @@ const Header = () => {
           </div>
         </a>
 
-        {/* Navigation */}
         <nav className="hidden md:flex items-center space-x-6 text-sm font-medium">
           <a href="#features" className="transition-smooth hover:text-primary">Features</a>
           <a href="#how-it-works" className="transition-smooth hover:text-primary">How It Works</a>
@@ -27,12 +27,34 @@ const Header = () => {
 
         <div className="flex items-center space-x-3">
           <ThemeToggle />
-          <Button variant="ghost" size="sm">
+          <Button variant="ghost" size="sm" className="hidden md:inline-flex">
             GitHub
           </Button>
-          <Button variant="hero" size="sm">
+          <Button variant="hero" size="sm" className="hidden md:inline-flex">
             Start Free
           </Button>
+          <Sheet>
+            <SheetTrigger asChild>
+              <Button variant="outline" size="icon" className="md:hidden" aria-label="Open menu">
+                <Menu className="h-5 w-5" />
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="right" className="w-full sm:max-w-sm">
+              <div className="px-1 py-2 space-y-2">
+                <a href="#features" className="block px-2 py-2 rounded-md hover:bg-muted">Features</a>
+                <a href="#how-it-works" className="block px-2 py-2 rounded-md hover:bg-muted">How It Works</a>
+                <a href="#security" className="block px-2 py-2 rounded-md hover:bg-muted">Security</a>
+                <a href="#docs" className="block px-2 py-2 rounded-md hover:bg-muted">Documentation</a>
+                <a href="#pricing" className="block px-2 py-2 rounded-md hover:bg-muted">Pricing</a>
+                <a href="/screenshots" className="block px-2 py-2 rounded-md hover:bg-muted">Screenshots</a>
+                <a href="/changelog" className="block px-2 py-2 rounded-md hover:bg-muted">Changelog</a>
+                <div className="pt-3 flex gap-2">
+                  <Button variant="ghost" className="flex-1">GitHub</Button>
+                  <Button variant="hero" className="flex-1">Start Free</Button>
+                </div>
+              </div>
+            </SheetContent>
+          </Sheet>
         </div>
       </div>
     </header>

--- a/packages/brochureware/src/index.css
+++ b/packages/brochureware/src/index.css
@@ -126,7 +126,7 @@ All colors MUST be HSL.
 }
 
 .legal-content {
-  @apply max-w-3xl mx-auto text-base leading-7;
+  @apply max-w-5xl mx-auto text-base leading-7;
 }
 .legal-content h1 {
   @apply text-3xl md:text-4xl font-bold mb-6 tracking-tight;

--- a/packages/brochureware/src/pages/Changelog.tsx
+++ b/packages/brochureware/src/pages/Changelog.tsx
@@ -125,7 +125,7 @@ const Changelog = () => {
   return (
     <div className="min-h-screen bg-background">
       <Header />
-      <main className="container max-w-5xl py-12 space-y-6">
+      <main className="container max-w-6xl lg:max-w-7xl px-4 md:px-6 py-12 space-y-6">
         <div className="space-y-2">
           <h1 className="text-3xl font-bold">Changelog</h1>
           <p className="text-muted-foreground">Recent changes and improvements</p>

--- a/packages/brochureware/src/pages/Screenshots.tsx
+++ b/packages/brochureware/src/pages/Screenshots.tsx
@@ -42,7 +42,7 @@ const Screenshots = () => {
   return (
     <div className="min-h-screen bg-background">
       <Header />
-      <main className="container max-w-7xl py-10">
+      <main className="container max-w-7xl px-4 md:px-6 py-10">
         <h1 className="text-3xl font-bold mb-6">Screenshots</h1>
         {!loaded && (
           <div className="text-muted-foreground">Loading…</div>

--- a/packages/brochureware/src/pages/legal/Cookie.tsx
+++ b/packages/brochureware/src/pages/legal/Cookie.tsx
@@ -5,7 +5,7 @@ const Cookie = () => {
   return (
     <div className="min-h-screen">
       <Header />
-      <main className="container mx-auto px-6 pt-28 pb-16">
+      <main className="container max-w-6xl lg:max-w-7xl px-4 md:px-6 pt-24 md:pt-28 pb-16">
         <section className="legal-content">
           <h1>Cookie Policy</h1>
           <p>Last updated: August 2025</p>

--- a/packages/brochureware/src/pages/legal/Privacy.tsx
+++ b/packages/brochureware/src/pages/legal/Privacy.tsx
@@ -5,7 +5,7 @@ const Privacy = () => {
   return (
     <div className="min-h-screen">
       <Header />
-      <main className="container mx-auto px-6 pt-28 pb-16">
+      <main className="container max-w-6xl lg:max-w-7xl px-4 md:px-6 pt-24 md:pt-28 pb-16">
         <section className="legal-content">
           <h1>Privacy Policy</h1>
 

--- a/packages/brochureware/src/pages/legal/Terms.tsx
+++ b/packages/brochureware/src/pages/legal/Terms.tsx
@@ -5,7 +5,7 @@ const Terms = () => {
   return (
     <div className="min-h-screen">
       <Header />
-      <main className="container mx-auto px-6 pt-28 pb-16">
+      <main className="container max-w-6xl lg:max-w-7xl px-4 md:px-6 pt-24 md:pt-28 pb-16">
         <section className="legal-content">
           <h1>Terms of Service</h1>
 


### PR DESCRIPTION
- Adds a mobile burger menu to brochureware header using the existing Sheet component for full navigation access on small screens.
- Widens the Changelog page container and legal content width, and adds responsive page padding to improve readability across breakpoints.

Scopes
- brochureware

Changes
- Header: mobile menu + hide CTAs on small screens
- Changelog: max-w increased with responsive padding
- Legal pages: widened containers
- Screenshots: add responsive padding

No breaking changes. Visual-only except for added mobile navigation.