### PR TITLE
chore(ci): pull GitHub releases before admin-ui build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Pull GitHub releases into changelog
+        run: scripts/pull-github-releases.sh
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - id: repo
         run: echo "name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
 
@@ -71,6 +76,11 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Pull GitHub releases into changelog
+        run: scripts/pull-github-releases.sh
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - id: repo
         run: echo "name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Run `scripts/pull-github-releases.sh` in Docker workflows prior to the multi-arch image builds so the Admin UI changelog is generated from GitHub releases at build time.

Details
- Adds a step to both amd64 and arm64 jobs to execute the script.
- Authenticates gh via `GH_TOKEN` for API access.
- Ensures `changelog/*.md` exists before `npm run build:admin` in Dockerfile.

This keeps the Admin UI `/changelog.json` in sync with published releases during image builds.