### PR TITLE
feat: theme-aware screenshots and viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 node_modules
 dist
 .env
+test-results-light
+test-results-dark
 test-results
 playwright-report
 test-screenshots
 .serena
+config.yaml
+test-data

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "npm run test -w @DarkAuth/test-suite",
     "test:report": "npm run test:report -w @DarkAuth/test-suite",
     "test:install": "npm run install:playwright -w @DarkAuth/test-suite",
+    "test:screenshots": "rm -rf packages/test-suite/test-results-light packages/test-suite/test-results-dark && npm --workspace @DarkAuth/test-suite run pretest && (cd packages/test-suite && COLOR_SCHEME=light npx playwright test --reporter=dot --workers=1 --output=test-results-light) || true && (cd packages/test-suite && COLOR_SCHEME=dark npx playwright test --reporter=dot --workers=1 --output=test-results-dark) || true && node packages/brochureware/scripts/collect-screenshots.js",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "format": "npm run format --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",

--- a/packages/test-suite/package.json
+++ b/packages/test-suite/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "pretest": "npm --workspace @DarkAuth/admin-ui run build && npm --workspace @DarkAuth/user-ui run build",
     "test": "npm run pretest && npx playwright test --reporter=dot",
+    "test:screenshots": "rm -rf test-results-light test-results-dark && npm run pretest && (COLOR_SCHEME=light npx playwright test --reporter=dot --workers=1 --output=test-results-light) || true && (COLOR_SCHEME=dark npx playwright test --reporter=dot --workers=1 --output=test-results-dark) || true && node ../brochureware/scripts/collect-screenshots.js",
     "test:report": "npm run pretest && npx playwright test && npx playwright show-report",
     "install:playwright": "npx playwright install"
   },

--- a/packages/test-suite/playwright.config.ts
+++ b/packages/test-suite/playwright.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     screenshot: 'on',
     video: 'on',
     viewport: { width: 1400, height: 800 },
+    colorScheme: process.env.COLOR_SCHEME === 'dark' ? 'dark' : process.env.COLOR_SCHEME === 'light' ? 'light' : undefined,
   },
   projects: [
     {

--- a/packages/test-suite/src/reload.ts
+++ b/packages/test-suite/src/reload.ts
@@ -1,1 +1,1 @@
-export const reloadToken = 1757147211743;
+export const reloadToken = 1757150873047;


### PR DESCRIPTION
- Add theme-aware screenshot collection and display in brochureware, with fallback to legacy index when themed output is absent.
- Enable Playwright colorScheme via env and add scripts to produce light/dark outputs.
- Add root script to capture themed screenshots and ignore generated artifacts.