### PR TITLE
chore: changelog hosting and static serving

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,6 @@ node_modules
 **/*.log
 docs
 specs
-changelog
 packages/test-suite
 packages/demo-app
 packages/brochureware

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ rpId: "localhost"         # Relying party identifier
 
 - Markdown entries live in `changelog/` as `YYYY-MM-DD.md`
 - Generate new entries from git: `npm run generate-changelog-entries`
-- The admin UI exposes `/changelog.json` and a page at `/changelog`
+- Brochureware publishes `/changelog.json`; Admin UI fetches from `https://darkauth.com/changelog.json`
 
 ## Zero-Knowledge Flow
 

--- a/packages/admin-ui/src/pages/Changelog.tsx
+++ b/packages/admin-ui/src/pages/Changelog.tsx
@@ -99,7 +99,7 @@ const Changelog: React.FC = () => {
   useEffect(() => {
     const loadChangelog = async () => {
       try {
-        const response = await fetch("/changelog.json");
+        const response = await fetch("https://darkauth.com/changelog.json");
         if (!response.ok) throw new Error(`Failed to fetch changelog: ${response.status}`);
         const data = await response.json();
         const es = data.entries || [];

--- a/packages/admin-ui/src/pages/Dashboard.tsx
+++ b/packages/admin-ui/src/pages/Dashboard.tsx
@@ -56,7 +56,7 @@ export default function Dashboard() {
       setAuditLogs(a.auditLogs || []);
 
       try {
-        const res = await fetch("/changelog.json");
+        const res = await fetch("https://darkauth.com/changelog.json");
         if (res.ok) {
           const data = await res.json();
           const entries = data.entries || [];

--- a/packages/admin-ui/vite.config.ts
+++ b/packages/admin-ui/vite.config.ts
@@ -1,6 +1,5 @@
 import { execSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
-import path, { join, resolve } from "node:path";
+import path, { resolve } from "node:path";
 import react from "@vitejs/plugin-react-swc";
 import { defineConfig } from "vite";
 
@@ -23,26 +22,15 @@ export default defineConfig({
   plugins: [
     react(),
     {
-      name: "git-changelog-plugin",
+      name: "preview-route",
       configureServer(server) {
-        server.middlewares.use((req, res, next) => {
-          if (req.url === "/changelog.json") {
-            const payload = buildChangelog();
-            res.statusCode = 200;
-            res.setHeader("Content-Type", "application/json");
-            res.end(payload);
-            return;
-          }
+        server.middlewares.use((req, _res, next) => {
           if (req.url?.startsWith("/preview")) {
             const qs = req.url.includes("?") ? req.url.slice(req.url.indexOf("?")) : "";
             req.url = `/branding/preview.html${qs}`;
           }
           next();
         });
-      },
-      generateBundle() {
-        const payload = buildChangelog();
-        this.emitFile({ type: "asset", fileName: "changelog.json", source: payload });
       },
     },
   ],
@@ -64,35 +52,3 @@ export default defineConfig({
     "import.meta.env.VITE_COMMIT_HASH": JSON.stringify(COMMIT_HASH || ""),
   },
 });
-
-function buildChangelog() {
-  try {
-    const changelogDir = join(process.cwd(), "../../changelog");
-    if (!existsSync(changelogDir))
-      return JSON.stringify({ generatedAt: new Date().toISOString(), entries: [] }, null, 2);
-    const files = readdirSync(changelogDir)
-      .filter((f) => f.endsWith(".md"))
-      .sort((a, b) => b.localeCompare(a));
-    const entries = files.map((filename) => {
-      const filePath = join(changelogDir, filename);
-      const content = readFileSync(filePath, "utf8");
-      const parts = content.split("---");
-      if (parts.length < 2) return { date: "", title: "", changes: [], filename };
-      const header = parts[0];
-      const body = parts.slice(1).join("---").trim();
-      let date = "";
-      let title = "";
-      const headerLines = header.split("\n");
-      for (const line of headerLines) {
-        if (line.startsWith("date: ")) date = line.replace("date: ", "").trim();
-        else if (line.startsWith("title: ")) title = line.replace("title: ", "").trim();
-      }
-      const changes = body ? [body] : [];
-      return { date, title, changes, filename };
-    });
-    return JSON.stringify({ generatedAt: new Date().toISOString(), entries }, null, 2);
-  } catch (error) {
-    console.error("Failed to build changelog:", error);
-    return JSON.stringify({ generatedAt: new Date().toISOString(), entries: [] }, null, 2);
-  }
-}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -27,6 +27,7 @@
 		"dotenv": "^17.2.2",
 		"drizzle-orm": "^0.44.5",
 		"drizzle-zod": "^0.8.3",
+		"@asteasolutions/zod-to-openapi": "^8.1.0",
 		"jose": "^6.1.0",
 		"opaque-ts": "file:../opaque-ts",
     "pg": "^8.16.3",
@@ -37,7 +38,6 @@
 		"zod": "^4.1.5"
 	},
 	"devDependencies": {
-		"@asteasolutions/zod-to-openapi": "^8.1.0",
 		"@biomejs/biome": "^2.2.3",
 		"@types/node": "^24.3.1",
 		"@types/pg": "^8.15.5",

--- a/packages/api/src/config/loadConfig.ts
+++ b/packages/api/src/config/loadConfig.ts
@@ -29,6 +29,9 @@ export function hasConfigFile(): boolean {
 }
 
 export function loadRootConfig(): RootConfig {
+  const envProxy = process.env.PROXY_UI ?? process.env.ZKAUTH_PROXY_UI;
+  const envProxyBool =
+    typeof envProxy === "string" ? /^(1|true|yes|on)$/i.test(envProxy) : undefined;
   const p = findConfigPath();
   if (!p) {
     return {
@@ -36,7 +39,7 @@ export function loadRootConfig(): RootConfig {
       postgresUri: "postgresql://DarkAuth:DarkAuth_password@localhost:5432/DarkAuth",
       userPort: 9080,
       adminPort: 9081,
-      proxyUi: true,
+      proxyUi: envProxyBool ?? false,
     } as RootConfig;
   }
   const raw = fs.readFileSync(p, "utf8");
@@ -47,7 +50,7 @@ export function loadRootConfig(): RootConfig {
       postgresUri: "postgresql://DarkAuth:DarkAuth_password@localhost:5432/DarkAuth",
       userPort: 9080,
       adminPort: 9081,
-      proxyUi: true,
+      proxyUi: envProxyBool ?? false,
     } as RootConfig;
   }
   return {
@@ -59,7 +62,7 @@ export function loadRootConfig(): RootConfig {
         : "postgresql://DarkAuth:DarkAuth_password@localhost:5432/DarkAuth",
     userPort: typeof parsed.userPort === "number" ? parsed.userPort : 9080,
     adminPort: typeof parsed.adminPort === "number" ? parsed.adminPort : 9081,
-    proxyUi: typeof parsed.proxyUi === "boolean" ? parsed.proxyUi : true,
+    proxyUi: envProxyBool ?? (typeof parsed.proxyUi === "boolean" ? parsed.proxyUi : false),
     kekPassphrase:
       typeof parsed.kekPassphrase === "string" && parsed.kekPassphrase.length > 0
         ? parsed.kekPassphrase

--- a/packages/api/src/http/proxy.ts
+++ b/packages/api/src/http/proxy.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { request as httpRequest } from "node:http";
 
@@ -6,8 +7,11 @@ export async function proxyToVite(
   res: ServerResponse,
   vitePort: number
 ): Promise<void> {
+  const explicitHost = process.env.VITE_HOST || process.env.PROXY_HOST;
+  const inDocker = fs.existsSync("/.dockerenv");
+  const hostname = explicitHost || (inDocker ? "host.docker.internal" : "localhost");
   const options = {
-    hostname: "localhost",
+    hostname,
     port: vitePort,
     path: req.url,
     method: req.method,

--- a/packages/api/src/reload.ts
+++ b/packages/api/src/reload.ts
@@ -1,1 +1,1 @@
-export const reloadToken = 1757113369487;
+export const reloadToken = 1757155247955;

--- a/packages/api/src/services/audit.ts
+++ b/packages/api/src/services/audit.ts
@@ -103,6 +103,7 @@ export function getClientIp(request: IncomingMessage): string {
 // Log audit event to database
 export async function logAuditEvent(context: Context, event: AuditEvent): Promise<void> {
   try {
+    if (!context?.db) return;
     const isUuid = (v: string | undefined) =>
       !!v &&
       /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/.test(

--- a/packages/brochureware/package.json
+++ b/packages/brochureware/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "predev": "node scripts/collect-screenshots.js",
     "dev": "npm run build && vite",
-    "prebuild": "node scripts/collect-screenshots.js",
+    "prebuild": "node scripts/collect-screenshots.js && node scripts/generate-changelog.js",
     "build": "npm run prebuild && vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",

--- a/packages/brochureware/scripts/generate-changelog.js
+++ b/packages/brochureware/scripts/generate-changelog.js
@@ -1,0 +1,47 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import path, { join, resolve } from "node:path";
+
+async function ensureDir(p) {
+  try {
+    await mkdir(p, { recursive: true });
+  } catch {}
+}
+
+function buildChangelog() {
+  try {
+    const changelogDir = join(process.cwd(), "../../changelog");
+    if (!existsSync(changelogDir)) return JSON.stringify({ generatedAt: new Date().toISOString(), entries: [] }, null, 2);
+    const files = readdirSync(changelogDir).filter((f) => f.endsWith(".md")).sort((a, b) => b.localeCompare(a));
+    const entries = files.map((filename) => {
+      const filePath = join(changelogDir, filename);
+      const content = readFileSync(filePath, "utf8");
+      const parts = content.split("---");
+      if (parts.length < 2) return { date: "", title: "", changes: [], filename };
+      const header = parts[0];
+      const body = parts.slice(1).join("---").trim();
+      let date = "";
+      let title = "";
+      const headerLines = header.split("\n");
+      for (const line of headerLines) {
+        if (line.startsWith("date: ")) date = line.replace("date: ", "").trim();
+        else if (line.startsWith("title: ")) title = line.replace("title: ", "").trim();
+      }
+      const changes = body ? [body] : [];
+      return { date, title, changes, filename };
+    });
+    return JSON.stringify({ generatedAt: new Date().toISOString(), entries }, null, 2);
+  } catch {
+    return JSON.stringify({ generatedAt: new Date().toISOString(), entries: [] }, null, 2);
+  }
+}
+
+async function main() {
+  const outDir = resolve(process.cwd(), "packages/brochureware/public");
+  await ensureDir(outDir);
+  const payload = buildChangelog();
+  await writeFile(join(outDir, "changelog.json"), payload, "utf8");
+}
+
+main().catch(() => process.exit(1));
+

--- a/packages/brochureware/vite.config.ts
+++ b/packages/brochureware/vite.config.ts
@@ -3,7 +3,7 @@ import react from "@vitejs/plugin-react-swc";
 import path, { join } from "path";
 import tailwind from "@tailwindcss/postcss";
 import autoprefixer from "autoprefixer";
-import { existsSync, readdirSync, readFileSync } from "fs";
+import { readFileSync } from "fs";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -18,25 +18,6 @@ export default defineConfig(({ mode }) => ({
   },
   plugins: [
     react(),
-    {
-      name: "git-changelog-plugin",
-      configureServer(server) {
-        server.middlewares.use((req, res, next) => {
-          if (req.url === "/changelog.json") {
-            const payload = buildChangelog();
-            res.statusCode = 200;
-            res.setHeader("Content-Type", "application/json");
-            res.end(payload);
-            return;
-          }
-          next();
-        });
-      },
-      generateBundle() {
-        const payload = buildChangelog();
-        this.emitFile({ type: "asset", fileName: "changelog.json", source: payload });
-      },
-    },
     {
       name: "static-logos-plugin",
       configureServer(server) {
@@ -72,31 +53,3 @@ export default defineConfig(({ mode }) => ({
     },
   },
 }));
-
-function buildChangelog() {
-  try {
-    const changelogDir = join(process.cwd(), "../../changelog");
-    if (!existsSync(changelogDir)) return JSON.stringify({ generatedAt: new Date().toISOString(), entries: [] }, null, 2);
-    const files = readdirSync(changelogDir).filter((f) => f.endsWith(".md")).sort((a, b) => b.localeCompare(a));
-    const entries = files.map((filename) => {
-      const filePath = join(changelogDir, filename);
-      const content = readFileSync(filePath, "utf8");
-      const parts = content.split("---");
-      if (parts.length < 2) return { date: "", title: "", changes: [], filename };
-      const header = parts[0];
-      const body = parts.slice(1).join("---").trim();
-      let date = "";
-      let title = "";
-      const headerLines = header.split("\n");
-      for (const line of headerLines) {
-        if (line.startsWith("date: ")) date = line.replace("date: ", "").trim();
-        else if (line.startsWith("title: ")) title = line.replace("title: ", "").trim();
-      }
-      const changes = body ? [body] : [];
-      return { date, title, changes, filename };
-    });
-    return JSON.stringify({ generatedAt: new Date().toISOString(), entries }, null, 2);
-  } catch {
-    return JSON.stringify({ generatedAt: new Date().toISOString(), entries: [] }, null, 2);
-  }
-}


### PR DESCRIPTION
- Host changelog via brochureware and remove dev/build routes from Admin UI
- Generate changelog.json during brochureware build; adjust README
- Improve API static serving (index fallback, base resolution) and Vite proxy host detection
- Move @asteasolutions/zod-to-openapi to dependencies
- Docker: include changelog, run API with pm2, and copy drizzle dir