### PR TITLE
fix(api,test-suite): require session for admin routes and enforce write role

### DIFF
--- a/packages/api/src/controllers/admin/clientCreate.ts
+++ b/packages/api/src/controllers/admin/clientCreate.ts
@@ -63,7 +63,9 @@ async function createClientHandler(
   ..._params: unknown[]
 ) {
   const session = await requireSession(context, request, true);
-  if (!session.adminRole) throw new ForbiddenError("Admin access required");
+  if (!session.adminRole || session.adminRole !== "write") {
+    throw new ForbiddenError("Write access required");
+  }
 
   const body = await readBody(request);
   const raw = parseJsonSafely(body);

--- a/packages/api/src/controllers/admin/clientUpdate.ts
+++ b/packages/api/src/controllers/admin/clientUpdate.ts
@@ -22,7 +22,9 @@ async function updateClientHandler(
   const clientId = params[0];
   if (!clientId) throw new ValidationError("Client ID is required");
   const session = await requireSession(context, request, true);
-  if (!session.adminRole) throw new ForbiddenError("Admin access required");
+  if (!session.adminRole || session.adminRole !== "write") {
+    throw new ForbiddenError("Write access required");
+  }
   const body = await readBody(request);
   const parsed = parseJsonSafely(body);
   if (!parsed || typeof parsed !== "object") throw new ValidationError("Invalid JSON body");

--- a/packages/api/src/controllers/admin/userCreate.ts
+++ b/packages/api/src/controllers/admin/userCreate.ts
@@ -22,8 +22,8 @@ async function createUserHandler(
     request,
     true
   );
-  if (!sessionData.adminRole) {
-    throw new ForbiddenError("Admin access required");
+  if (!sessionData.adminRole || sessionData.adminRole !== "write") {
+    throw new ForbiddenError("Write access required");
   }
 
   const body = await readBody(request);

--- a/packages/api/src/controllers/admin/userDelete.ts
+++ b/packages/api/src/controllers/admin/userDelete.ts
@@ -27,8 +27,8 @@ async function deleteUserHandler(
     request,
     true
   );
-  if (!sessionData.adminRole) {
-    throw new ForbiddenError("Admin access required");
+  if (!sessionData.adminRole || sessionData.adminRole !== "write") {
+    throw new ForbiddenError("Write access required");
   }
 
   await deleteUserModel(context, sub);

--- a/packages/api/src/controllers/admin/userUpdate.ts
+++ b/packages/api/src/controllers/admin/userUpdate.ts
@@ -23,8 +23,8 @@ async function updateUserHandler(
     request,
     true
   );
-  if (!sessionData.adminRole) {
-    throw new ForbiddenError("Admin access required");
+  if (!sessionData.adminRole || sessionData.adminRole !== "write") {
+    throw new ForbiddenError("Write access required");
   }
 
   const body = await readBody(request);

--- a/packages/api/src/controllers/user/authorizeFinalize.ts
+++ b/packages/api/src/controllers/user/authorizeFinalize.ts
@@ -95,7 +95,6 @@ export const postAuthorizeFinalize = withRateLimit("opaque")(
       }
 
       // Store authorization code with PKCE support
-      console.log("[authorize] issue code", code, "for", pendingRequest.clientId);
       await createAuthCode(context, {
         code,
         clientId: pendingRequest.clientId,

--- a/packages/brochureware/public/changelog.json
+++ b/packages/brochureware/public/changelog.json
@@ -1,6 +1,14 @@
 {
-  "generatedAt": "2025-09-10T18:46:56.848Z",
+  "generatedAt": "2025-09-10T20:22:34.627Z",
   "entries": [
+    {
+      "date": "2025-09-10",
+      "title": "v1.0.8",
+      "changes": [
+        "This release refreshes the Admin Settings experience with an accordion layout and in-place JSON editing, introduces API metadata for settings with seeded descriptions, fixes install token handling during bootstrap, and updates tests and docs accordingly.\n\n## ✨ Features\n\n### 🔧 Admin Settings UI\n- Refactor Settings UI into accordion sections with a JSON editor and CSS Modules\n\n### 🧩 API Settings Metadata\n- Add settings description field and seed; update services and schema\n\n## 🐛 Fixes\n\n- Accept install token via query parameter and respect `adminCreated` during install\n\n## 🧪 Tests\n\n- Adjust reload integration to account for Settings changes\n- Bump reload token for test stability\n\n## 📚 Chores\n\n- Update brochure site changelog data\n- Add Settings UI improvements plan and refine release creation steps"
+      ],
+      "filename": "v1.0.8.md"
+    },
     {
       "date": "2025-09-10",
       "title": "v1.0.7",

--- a/packages/test-suite/src/reload.ts
+++ b/packages/test-suite/src/reload.ts
@@ -1,1 +1,1 @@
-export const reloadToken = 1757530065290;
+export const reloadToken = 1757535217062;


### PR DESCRIPTION
- Enforces write-only admin role for admin mutation endpoints\n- Adds session token pre-check for admin routes with a small public whitelist\n- Removes debug log from authorize finalize\n- Bumps test-suite reload token\n- Updates brochureware changelog data