### PR TITLE
Fix release notes parsing fallback

### DIFF
--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -48,15 +48,21 @@ const permission = {
 };
 
 const child = spawn("npx", args, {
-  stdio: ["ignore", "pipe", "inherit"],
+  stdio: ["ignore", "pipe", "pipe"],
   env: {
     ...process.env,
     OPENCODE_PERMISSION: JSON.stringify(permission),
   },
 });
 let output = "";
+let errorOutput = "";
 child.stdout.on("data", (chunk) => {
   output += chunk.toString();
+});
+child.stderr.on("data", (chunk) => {
+  const chunkString = chunk.toString();
+  errorOutput += chunkString;
+  process.stderr.write(chunkString);
 });
 
 const exitCode = await new Promise((resolveExit) => {
@@ -67,17 +73,35 @@ if (exitCode !== 0) {
   process.exit(exitCode);
 }
 
-const cleaned = output.replace(/\u001b\[[0-9;]*m/g, "");
-const startIndex = cleaned.indexOf(startMarker);
-const endIndex = cleaned.indexOf(endMarker);
-if (startIndex === -1 || endIndex === -1 || endIndex <= startIndex) {
+const cleanOutput = (text) => text.replace(/\u001b\[[0-9;]*m/g, "");
+const extractNotes = (text) => {
+  const startIndex = text.indexOf(startMarker);
+  const endIndex = text.indexOf(endMarker);
+  if (startIndex === -1 || endIndex === -1 || endIndex <= startIndex) {
+    return null;
+  }
+  return text.slice(startIndex + startMarker.length, endIndex).replace(/^\s+|\s+$/g, "");
+};
+const extractFallbackNotes = (text) => {
+  const lines = text.split("\n");
+  const startLineIndex = lines.findIndex((line) => /^(#{1,6}\s|[-*]\s|\d+\.\s)/.test(line));
+  if (startLineIndex === -1) {
+    return null;
+  }
+  return lines.slice(startLineIndex).join("\n").replace(/^\s+|\s+$/g, "");
+};
+const cleanedOutput = cleanOutput(output);
+const cleanedErrorOutput = cleanOutput(errorOutput);
+const combinedOutput = `${cleanedOutput}\n${cleanedErrorOutput}`.trim();
+let notes =
+  extractNotes(cleanedOutput) || extractNotes(cleanedErrorOutput) || extractNotes(combinedOutput);
+if (!notes) {
+  notes = extractFallbackNotes(cleanedOutput) || extractFallbackNotes(cleanedErrorOutput);
+}
+if (!notes) {
   console.error("Release notes markers not found in OpenCode output");
   process.exit(1);
 }
-
-const notes = cleaned
-  .slice(startIndex + startMarker.length, endIndex)
-  .replace(/^\s+|\s+$/g, "");
 
 if (!notes) {
   console.error("Release notes content missing");


### PR DESCRIPTION
### Motivation
- The release-note generator aborted the release when OpenCode emitted notes on stderr or omitted the explicit markers, causing the CI release step to fail.

### Description
- Update `scripts/generate-release-notes.mjs` to capture the child process `stderr`, strip ANSI sequences, attempt marker extraction from `stdout`, `stderr`, and their combination, and fall back to a marker-free heuristic that extracts the first markdown-like block.

### Testing
- Ran `npm run tidy` which completed successfully.
- Ran `npm run build` which completed but encountered an unrelated Puppeteer/Chrome launch error during whitepaper generation (`libatk-1.0.so.0` missing); the release-notes parser changes behaved as expected during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977ed8d5fd08323b9306e667b5fbf6a)