### PR TITLE
fix(release): return raw release notes body

### DIFF
--- a/.github/prompts/github-create-release.md
+++ b/.github/prompts/github-create-release.md
@@ -6,5 +6,5 @@ Rules:
 - Do not create or modify any files.
 - Do not attempt to publish a release.
 - You may use read-only commands to inspect files and git history if available.
-- Output markdown only between the markers `<!--release-notes-start-->` and `<!--release-notes-end-->`.
-- Do not include any extra text outside the markers.
+- Use parallel agents when exploring.
+- Output the markdown changelog body only, with no extra text.


### PR DESCRIPTION
## Summary
- return raw release notes output without markers
- switch release notes model to openrouter/anthropic/claude-haiku-4.5
- instruct OpenCode to use parallel agents when exploring

## Testing
- npm run tidy
- npm run build
