### PR TITLE
fix(user-ui): align button loading spinner

### DIFF
--- a/packages/user-ui/src/App.css
+++ b/packages/user-ui/src/App.css
@@ -805,6 +805,13 @@ body {
   margin-bottom: 1rem;
 }
 
+button .loading-spinner {
+  width: 1rem;
+  height: 1rem;
+  border-width: 2px;
+  margin-bottom: 0;
+}
+
 @keyframes spin {
   to {
     transform: rotate(360deg);

--- a/packages/user-ui/src/components/Button.module.css
+++ b/packages/user-ui/src/components/Button.module.css
@@ -1,4 +1,9 @@
 .button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  line-height: 1;
   padding: 0.75rem 1rem;
   border-radius: 0.5rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- Align button contents so the loading spinner stays centered
- Reduce spinner size inside buttons to avoid text shift

## Testing
- npm run tidy
- npm run build
