### PR TITLE
fix(release): build release image on native arch runners

### DIFF
--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -99,15 +99,16 @@ jobs:
           RELEASE_DEPLOY_STORAGE_ZONE: ${{ vars.RELEASE_DEPLOY_STORAGE_ZONE }}
           RELEASE_DEPLOY_ACCESS_KEY: ${{ secrets.RELEASE_DEPLOY_ACCESS_KEY }}
         run: node scripts/deploy-release-screenshots.mjs
-  release-image:
+  release-image-amd64:
     runs-on: ubuntu-latest
     needs: release
     if: needs.release.outputs.no_release != 'true'
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -115,11 +116,67 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build release image
+      - name: Build amd64 image
         uses: docker/build-push-action@v6
+        id: build
         with:
           context: .
           file: Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/${{ needs.release.outputs.repo }}:${{ needs.release.outputs.tag }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=image,name=ghcr.io/${{ needs.release.outputs.repo }},name-canonical=true,push-by-digest=true
+
+  release-image-arm64:
+    runs-on: ubuntu-24.04-arm
+    needs: release
+    if: needs.release.outputs.no_release != 'true'
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build arm64 image
+        uses: docker/build-push-action@v6
+        id: build
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=image,name=ghcr.io/${{ needs.release.outputs.repo }},name-canonical=true,push-by-digest=true
+
+  release-image:
+    runs-on: ubuntu-latest
+    needs: [release, release-image-amd64, release-image-arm64]
+    if: needs.release.outputs.no_release != 'true'
+    steps:
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create release manifest
+        env:
+          IMAGE: ghcr.io/${{ needs.release.outputs.repo }}
+          TAG: ${{ needs.release.outputs.tag }}
+          AMD64_DIGEST: ${{ needs.release-image-amd64.outputs.digest }}
+          ARM64_DIGEST: ${{ needs.release-image-arm64.outputs.digest }}
+        run: |
+          docker buildx imagetools create \
+            -t "${IMAGE}:${TAG}" \
+            "${IMAGE}@${AMD64_DIGEST}" \
+            "${IMAGE}@${ARM64_DIGEST}"


### PR DESCRIPTION
## Summary
- split release image build into native `amd64` and native `arm64` jobs
- remove QEMU-based multi-arch build path from `trigger-release`
- add Buildx GHA cache for both architecture builds
- publish the final release tag via a manifest assembled from both digests

## Why
Recent `release-image` runs became slow and unstable, with arm64 builds hitting `qemu` illegal instruction errors during `npm ci`.

## Validation
- npm run tidy
- npm run build
