### PR TITLE
fix(api): preserve OTP enforcement during force_otp migration

### DIFF
--- a/packages/api/drizzle/0015_org_force_otp.sql
+++ b/packages/api/drizzle/0015_org_force_otp.sql
@@ -1,6 +1,16 @@
 ALTER TABLE "organizations"
 ADD COLUMN IF NOT EXISTS "force_otp" boolean NOT NULL DEFAULT false;
 --> statement-breakpoint
+UPDATE "organizations" o
+SET "force_otp" = true
+WHERE EXISTS (
+  SELECT 1
+  FROM "organization_members" om
+  INNER JOIN "organization_member_roles" omr ON omr."organization_member_id" = om."id"
+  INNER JOIN "roles" r ON r."id" = omr."role_id"
+  WHERE om."organization_id" = o."id" AND r."key" = 'otp_required'
+);
+--> statement-breakpoint
 DELETE FROM "organization_member_roles" omr
 USING "roles" r
 WHERE omr."role_id" = r."id" AND r."key" = 'otp_required';


### PR DESCRIPTION
### Motivation
- The migration `0015_org_force_otp.sql` added `organizations.force_otp` defaulting to `false` and removed the legacy `otp_required` role without migrating existing enforcement, which would silently disable OTP for orgs after upgrade. 
- This change restores the original MFA enforcement semantics so organizations that previously required OTP continue to do so after the migration.

### Description
- Updated `packages/api/drizzle/0015_org_force_otp.sql` to backfill `organizations.force_otp = true` for any organization that had a member assigned the legacy `otp_required` role. 
- Left the existing cleanup steps that delete `organization_member_roles`, `role_permissions`, and the `roles` entry for `otp_required` unchanged. 
- The change is a minimal migration-only fix intended to preserve behavior without altering runtime OTP logic.

### Testing
- Ran `npm run tidy` which completed successfully (repo-wide Biome warnings/info remain but no errors). 
- Ran `npm run build` which completed successfully for the workspaces though the brochureware prebuild logged a missing system library for Puppeteer PDF generation but did not fail the overall build. 
- Attempted `npm --workspace @DarkAuth/api test -- src/controllers/user/opaqueLoginFinish.test.ts`, but tests could not be executed in this environment because Node v20 cannot run `.ts` test files directly and reported `ERR_UNKNOWN_FILE_EXTENSION`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0308a57c483238a1bf9491e0fd9ea)