### PR TITLE
fix(api): prevent OTP backup code replay

### DIFF
--- a/packages/api/src/models/otp.ts
+++ b/packages/api/src/models/otp.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { verify as argonVerify, hash } from "argon2";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { otpBackupCodes, otpConfigs, users } from "../db/schema.ts";
 import { ValidationError } from "../errors.ts";
 import { getSetting } from "../services/settings.ts";
@@ -184,7 +184,13 @@ export async function verifyOtpCode(
     const backupCodes = await context.db
       .select({ id: otpBackupCodes.id, codeHash: otpBackupCodes.codeHash })
       .from(otpBackupCodes)
-      .where(and(eq(otpBackupCodes.cohort, cohort), eq(otpBackupCodes.subjectId, subjectId)));
+      .where(
+        and(
+          eq(otpBackupCodes.cohort, cohort),
+          eq(otpBackupCodes.subjectId, subjectId),
+          isNull(otpBackupCodes.usedAt)
+        )
+      );
     for (const backupCode of backupCodes) {
       const isMatch = await argonVerify(backupCode.codeHash, code).catch(() => false);
       if (isMatch) {
@@ -200,7 +206,7 @@ export async function verifyOtpCode(
         await context.db
           .update(otpBackupCodes)
           .set({ usedAt: new Date() })
-          .where(eq(otpBackupCodes.id, backupCode.id));
+          .where(and(eq(otpBackupCodes.id, backupCode.id), isNull(otpBackupCodes.usedAt)));
         return { success: true };
       }
     }


### PR DESCRIPTION
### Motivation
- The OTP backup-code verification path did not exclude entries where `usedAt` was already set, allowing previously consumed backup codes to be replayed indefinitely and bypass one-time semantics.

### Description
- Added `isNull` import from `drizzle-orm` and changed the backup-code lookup to only select rows where `usedAt IS NULL` in `packages/api/src/models/otp.ts`.
- Hardened the consume/update statement to only set `usedAt` when the row is still unused by adding `isNull(otpBackupCodes.usedAt)` to the update `WHERE` clause in `packages/api/src/models/otp.ts`.
- These changes enforce one-time use while preserving the existing OTP verification flow and behavior for TOTP codes.

### Testing
- Ran `npm run tidy` at the repo root which completed (existing linter warnings/info remain unrelated to this change). 
- Ran `npm run build` at the repo root which completed (brochureware prebuild logged a missing puppeteer dependency but overall build finished). 
- Ran `npm -w packages/api test` which failed in this environment due to Node executing `.ts` tests without a configured TypeScript test loader (`ERR_UNKNOWN_FILE_EXTENSION`), which is unrelated to the OTP logic changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b04773ab388323a0227eb911f226fd)