### PR TITLE
refactor(brochureware,user-ui,test-suite): remove legacy group references

### DIFF
--- a/packages/brochureware/src/pages/Features.tsx
+++ b/packages/brochureware/src/pages/Features.tsx
@@ -37,7 +37,7 @@ const features: Feature[] = [
     title: "TOTP MFA (Users & Admins)",
     bullets: [
       "Setup and verify with backup codes",
-      "Per-group and cohort enforcement with rate limits",
+      "Per-organization enforcement with rate limits",
       "AMR includes otp; ACR indicates MFA",
     ],
     tags: ["OTP", "TOTP", "MFA"],
@@ -84,7 +84,7 @@ const features: Feature[] = [
     icon: Settings,
     title: "Admin: Clients, Settings, RBAC",
     bullets: [
-      "Manage clients, settings, users, groups, permissions",
+      "Manage clients, settings, users, roles, permissions, and organizations",
       "JWKS list and rotate",
       "OpenAPI served for Admin APIs",
     ],
@@ -119,10 +119,10 @@ const features: Feature[] = [
   },
   {
     icon: Hash,
-    title: "Claims: Permissions and Groups",
+    title: "Claims: Permissions",
     bullets: [
-      "ID tokens can include permissions and groups",
-      "Computed from direct and group‑derived access",
+      "ID tokens can include permissions",
+      "Computed from direct and organization role-derived access",
     ],
     tags: ["Custom Claims"],
   },

--- a/packages/brochureware/src/pages/docs/api/Admin.tsx
+++ b/packages/brochureware/src/pages/docs/api/Admin.tsx
@@ -13,7 +13,6 @@ POST /admin/users
 GET /admin/users/{sub}
 PATCH /admin/users/{sub}
 DELETE /admin/users/{sub}
-PUT /admin/users/{sub}/groups
 GET /admin/users/{sub}/permissions`;
 
 const authzOps = `GET /admin/clients
@@ -21,9 +20,7 @@ POST /admin/clients
 GET /admin/roles
 POST /admin/roles
 GET /admin/permissions
-POST /admin/permissions
-GET /admin/groups
-POST /admin/groups`;
+POST /admin/permissions`;
 
 const adminApiPage = () => {
   return (
@@ -67,7 +64,7 @@ const adminApiPage = () => {
               <code>{userOps}</code>
             </pre>
             <p className="mt-2 text-sm text-muted-foreground">
-              Includes admin user CRUD and user-to-group/permission management.
+              Includes admin user CRUD and direct permission management.
             </p>
           </CardContent>
         </Card>
@@ -81,7 +78,7 @@ const adminApiPage = () => {
               <code>{authzOps}</code>
             </pre>
             <p className="mt-2 text-sm text-muted-foreground">
-              Manage clients, roles, permissions, groups, and org structures.
+              Manage clients, roles, permissions, and org structures.
             </p>
           </CardContent>
         </Card>

--- a/packages/brochureware/src/pages/docs/api/ApiOverview.tsx
+++ b/packages/brochureware/src/pages/docs/api/ApiOverview.tsx
@@ -47,7 +47,7 @@ const ApiOverviewPage = () => {
             </div>
             <ul className="list-disc space-y-2 pl-5 text-base text-muted-foreground">
               <li>Tenant bootstrapping and identity providers.</li>
-              <li>Full RBAC management: clients, users, roles, permissions, groups, orgs.</li>
+              <li>Full RBAC management: clients, users, roles, permissions, and orgs.</li>
               <li>Audit trail and settings surfaces.</li>
               <li>Admin-only OTP and security tooling.</li>
             </ul>

--- a/packages/brochureware/src/pages/docs/developers/client-apis/UsersApi.tsx
+++ b/packages/brochureware/src/pages/docs/developers/client-apis/UsersApi.tsx
@@ -69,7 +69,6 @@ const managementResponseExample = `{
       "email": "target@example.com",
       "name": "Directory Target",
       "createdAt": "2026-01-24T19:17:27.000Z",
-      "groups": ["support", "ops"],
       "permissions": ["darkauth.users:read"]
     }
   ]

--- a/packages/brochureware/src/pages/docs/guides/OtpPolicy.tsx
+++ b/packages/brochureware/src/pages/docs/guides/OtpPolicy.tsx
@@ -23,8 +23,8 @@ const OtpPolicyPage = () => {
         </CardHeader>
         <CardContent>
           <p className="text-base text-muted-foreground">
-            OTP in DarkAuth is implemented as an explicit policy layer. It can be enabled for users, users
-            in groups, or role-based scenarios where step-up authentication is required.
+            OTP in DarkAuth is implemented as an explicit policy layer. It can be enabled for users,
+            organizations, or role-based scenarios where step-up authentication is required.
           </p>
         </CardContent>
       </Card>

--- a/packages/test-suite/tests/admin/organizations/default-organization.spec.ts
+++ b/packages/test-suite/tests/admin/organizations/default-organization.spec.ts
@@ -11,7 +11,7 @@ test.describe('Admin - Organizations Default', () => {
   let adminCred = { email: FIXED_TEST_ADMIN.email, password: FIXED_TEST_ADMIN.password };
 
   test.beforeAll(async () => {
-    servers = await createTestServers({ testName: 'admin-groups-default' });
+    servers = await createTestServers({ testName: 'admin-organizations-default' });
     await installDarkAuth({
       adminUrl: servers.adminUrl,
       adminEmail: FIXED_TEST_ADMIN.email,

--- a/packages/test-suite/tests/admin/users/default-organization-membership.spec.ts
+++ b/packages/test-suite/tests/admin/users/default-organization-membership.spec.ts
@@ -9,7 +9,7 @@ test.describe('Admin - Default organization membership', () => {
   let servers: TestServers;
 
   test.beforeAll(async () => {
-    servers = await createTestServers({ testName: 'admin-default-group-assignment' });
+    servers = await createTestServers({ testName: 'admin-default-organization-membership' });
     await installDarkAuth({
       adminUrl: servers.adminUrl,
       adminEmail: FIXED_TEST_ADMIN.email,

--- a/packages/user-ui/src/pages/Authorize.tsx
+++ b/packages/user-ui/src/pages/Authorize.tsx
@@ -166,8 +166,6 @@ function getScopeDescription(scope: string): string {
       return "Access your basic profile information";
     case "email":
       return "Access your email address";
-    case "groups":
-      return "Access your group memberships";
     case "permissions":
       return "Access your permissions";
     default:


### PR DESCRIPTION
## Summary
- remove remaining product-facing legacy group references from brochureware docs
- remove the leftover `groups` scope description from the user authorize screen
- rename default organization test specs away from legacy group naming
- leave historical migrations untouched for existing demo and test environments

## Validation
- npm run tidy
- npm run build

## Notes
- brochureware prebuild still logs the existing Puppeteer Chrome warning while generating the whitepaper PDF
- overall build completed successfully
