### PR TITLE
fix(api): preserve signJWT issuer claim

### DIFF
--- a/packages/api/src/services/jwks.test.ts
+++ b/packages/api/src/services/jwks.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { decodeJwt, exportJWK, generateKeyPair } from "jose";
+import type { Context } from "../types.ts";
+import { signJWT } from "./jwks.ts";
+
+function createContextWithKey(issuer: string) {
+  return async () => {
+    const { publicKey, privateKey } = await generateKeyPair("EdDSA");
+    const publicJwk = await exportJWK(publicKey);
+    const privateJwk = await exportJWK(privateKey);
+
+    const context = {
+      config: {
+        issuer,
+      },
+      db: {
+        query: {
+          jwks: {
+            findFirst: async () => ({
+              kid: "test-kid",
+              publicJwk,
+              privateJwk,
+              privateJwkEnc: null,
+              createdAt: new Date(),
+            }),
+          },
+        },
+      },
+    } as unknown as Context;
+
+    return context;
+  };
+}
+
+test("signJWT preserves payload issuer when provided", async () => {
+  const context = await createContextWithKey("http://localhost:9080")();
+
+  const token = await signJWT(
+    context,
+    {
+      sub: "user-sub",
+      iss: "https://auth.puzed.com",
+    },
+    "5m"
+  );
+
+  const claims = decodeJwt(token);
+  assert.equal(claims.iss, "https://auth.puzed.com");
+});
+
+test("signJWT falls back to context issuer when payload issuer is absent", async () => {
+  const context = await createContextWithKey("https://auth.puzed.com")();
+
+  const token = await signJWT(
+    context,
+    {
+      sub: "user-sub",
+    },
+    "5m"
+  );
+
+  const claims = decodeJwt(token);
+  assert.equal(claims.iss, "https://auth.puzed.com");
+});

--- a/packages/api/src/services/jwks.test.ts
+++ b/packages/api/src/services/jwks.test.ts
@@ -1,14 +1,13 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { decodeJwt, exportJWK, generateKeyPair } from "jose";
+import { decodeJwt } from "jose";
 import type { Context } from "../types.ts";
-import { signJWT } from "./jwks.ts";
+import { generateEdDSAKeyPair, signJWT } from "./jwks.ts";
 
 function createContextWithKey(issuer: string) {
   return async () => {
-    const { publicKey, privateKey } = await generateKeyPair("EdDSA");
-    const publicJwk = await exportJWK(publicKey);
-    const privateJwk = await exportJWK(privateKey);
+    const { publicJwk, privateJwk } = await generateEdDSAKeyPair();
+    const privateJwkEnc = Buffer.from(JSON.stringify(privateJwk));
 
     const context = {
       config: {
@@ -20,11 +19,17 @@ function createContextWithKey(issuer: string) {
             findFirst: async () => ({
               kid: "test-kid",
               publicJwk,
-              privateJwk,
-              privateJwkEnc: null,
+              privateJwkEnc,
               createdAt: new Date(),
             }),
           },
+        },
+      },
+      services: {
+        kek: {
+          decrypt: async (data: Buffer) => data,
+          encrypt: async (data: Buffer) => data,
+          isAvailable: () => true,
         },
       },
     } as unknown as Context;

--- a/packages/api/src/services/jwks.ts
+++ b/packages/api/src/services/jwks.ts
@@ -118,13 +118,15 @@ export async function signJWT(
   expiresIn = "5m"
 ): Promise<string> {
   const { kid, privateKey } = await getLatestSigningKey(context);
+  const issuer =
+    typeof payload.iss === "string" && payload.iss.length > 0 ? payload.iss : context.config.issuer;
 
   const jwt = new SignJWT(payload)
     .setProtectedHeader({ alg: "EdDSA", kid })
     .setIssuedAt()
     .setJti(generateRandomString(32))
     .setExpirationTime(expiresIn)
-    .setIssuer(context.config.issuer);
+    .setIssuer(issuer);
 
   // Set audience if provided in payload
   if (payload.aud) {


### PR DESCRIPTION
## Summary
- `signJWT` now preserves a provided payload `iss` claim and only falls back to `context.config.issuer` when missing.
- Added regression tests for both payload-issuer preservation and configured-issuer fallback.

## Testing
- `npm run tidy` (not available in this environment: `biome` is not installed)
- `npm run build` (not available in this environment: `tsc`, `vite`, and `jsdom` are missing)
