### PR TITLE
fix(admin-ui,api): cover branding page regressions

### DIFF
--- a/packages/admin-ui/src/pages/Branding.tsx
+++ b/packages/admin-ui/src/pages/Branding.tsx
@@ -79,6 +79,19 @@ function cloneImage(value: BrandingImage): BrandingImage {
   return { data: value.data, mimeType: value.mimeType };
 }
 
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  let binary = "";
+
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    const chunk = bytes.subarray(offset, offset + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+
+  return btoa(binary);
+}
+
 function getDefaultLogoSvg(color: string) {
   return `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
@@ -275,9 +288,16 @@ export default function Branding() {
       toast({ title: "Image too large (max 2MB)", variant: "destructive" });
       return;
     }
-    const buf = await file.arrayBuffer();
-    const b64 = btoa(String.fromCharCode(...new Uint8Array(buf)));
-    setter({ data: b64, mimeType: file.type });
+    try {
+      const buf = await file.arrayBuffer();
+      setter({ data: arrayBufferToBase64(buf), mimeType: file.type });
+    } catch (e) {
+      toast({
+        title: "Could not load image",
+        description: e instanceof Error ? e.message : "Failed to read selected image",
+        variant: "destructive",
+      });
+    }
   };
 
   const copyCurrentToOther = () => {

--- a/packages/api/src/http/routers/userRouter.test.ts
+++ b/packages/api/src/http/routers/userRouter.test.ts
@@ -118,3 +118,50 @@ test("user router wires GET /scope-descriptions validation failures", async () =
     error_description: "Invalid input: expected string, received undefined",
   });
 });
+
+test("user router exposes page background CSS variables for branded user pages", async () => {
+  const values = [
+    {
+      backgroundColor: "#123456",
+      backgroundGradientEnd: "#abcdef",
+      brandColor: "#654321",
+      primaryBackgroundColor: "#fedcba",
+    },
+    {
+      backgroundColor: "#0a0b0c",
+      backgroundGradientEnd: "#101112",
+      brandColor: "#c0ffee",
+      primaryBackgroundColor: "#decade",
+    },
+    undefined,
+    "",
+  ];
+  const context = {
+    db: {
+      query: {
+        settings: {
+          findFirst: mock.fn(() => Promise.resolve({ value: values.shift() })),
+        },
+      },
+    },
+    services: { install: {} },
+    logger: createLogger(),
+  };
+
+  const router = createUserRouter(context as never);
+  const request = createRequest("/branding/custom.css");
+  const response = createMockResponse();
+
+  await router(request as IncomingMessage, response as ServerResponse);
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.getHeader("content-type"), "text/css; charset=utf-8");
+  assert.match(response.body, /:root\{[^}]*--da-page-bg:#123456/);
+  assert.match(response.body, /:root\[data-da-theme='light'\]\{[^}]*--da-page-bg:#123456/);
+  assert.match(response.body, /:root\[data-da-theme='dark'\]\{[^}]*--da-page-bg:#0a0b0c/);
+  assert.match(
+    response.body,
+    /@media \(prefers-color-scheme: dark\)\{:root:not\(\[data-da-theme\]\)\{[^}]*--da-page-bg:#0a0b0c/
+  );
+  assert.match(response.body, /body\{background:linear-gradient\(var\(--da-bg-angle\)/);
+});

--- a/packages/api/src/http/routers/userRouter.ts
+++ b/packages/api/src/http/routers/userRouter.ts
@@ -156,6 +156,7 @@ export function createUserRouter(context: Context) {
         const darkBorder = readColor(cd, "borderColor", "#374151", "border");
         const darkBg = readColor(cd, "backgroundColor", "#1f2937", "backgroundGradientStart");
         const cssVarsLight: Record<string, string> = {
+          "--da-page-bg": lightBg,
           "--da-bg-gradient-start": lightBg,
           "--da-bg-gradient-end": String(c.backgroundGradientEnd || lightBg),
           "--da-bg-angle": String(c.backgroundAngle || "135deg"),
@@ -195,6 +196,7 @@ export function createUserRouter(context: Context) {
           "--gray-50": lightBg,
         };
         const cssVarsDark: Record<string, string> = {
+          "--da-page-bg": darkBg,
           "--da-bg-gradient-start": darkBg,
           "--da-bg-gradient-end": String(cd.backgroundGradientEnd || darkBg),
           "--da-bg-angle": String(cd.backgroundAngle || "135deg"),

--- a/packages/test-suite/tests/admin/branding/branding.spec.ts
+++ b/packages/test-suite/tests/admin/branding/branding.spec.ts
@@ -192,4 +192,31 @@ test.describe('Admin - Branding Settings', () => {
 
     await expect(lightColorInput).toHaveValue('#ff69b4');
   });
+
+  test('can upload and save a large logo without corrupting base64 data', async ({ page }) => {
+    await page.waitForSelector('text="Brand Color"', { timeout: 10000 });
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><rect width="24" height="24" fill="#123456"/><metadata>${'x'.repeat(200_000)}</metadata></svg>`;
+    const expectedLogo = Buffer.from(svg).toString('base64');
+
+    await page.locator('input[type="file"]').first().setInputFiles({
+      name: 'large-logo.svg',
+      mimeType: 'image/svg+xml',
+      buffer: Buffer.from(svg)
+    });
+
+    const logoPreview = page.getByAltText('Logo preview');
+    await expect(logoPreview).toBeVisible();
+    await expect
+      .poll(async () => await logoPreview.getAttribute('src'), { timeout: 5000 })
+      .toBe(`data:image/svg+xml;base64,${expectedLogo}`);
+
+    await page.locator('button:has-text("Save")').first().click();
+    await expect(page.getByText('Branding saved').first()).toBeVisible({ timeout: 5000 });
+
+    await page.locator('button:has-text("Reload")').first().click();
+    await expect(page.getByAltText('Logo preview')).toHaveAttribute(
+      'src',
+      `data:image/svg+xml;base64,${expectedLogo}`
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- expose the generated branding page background variable in user custom CSS for light, explicit dark, and system dark modes
- make branding image uploads encode array buffers in chunks so larger logos do not break the admin page
- add API and Playwright regression coverage for both branding fixes

## Verification
- node --env-file-if-exists=../../.env --test src/http/routers/userRouter.test.ts
- npm run test -w @DarkAuth/api
- cd packages/test-suite && npx playwright test tests/admin/branding/branding.spec.ts --workers=1
- npm run tidy
- npm run build
