### PR TITLE
Fix auth schema drift and release image tagging

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,9 +16,19 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - id: repo
         run: echo "name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+
+      - id: app_version
+        run: |
+          version="$(git describe --tags --exact-match 2>/dev/null || git describe --tags --abbrev=0 2>/dev/null || true)"
+          if [ -z "$version" ]; then
+            version="$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' package.json | head -n 1)"
+          fi
+          echo "value=$version" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v3
 
@@ -35,7 +45,6 @@ jobs:
         with:
           images: ghcr.io/${{ steps.repo.outputs.name }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
             type=sha
             type=ref,event=branch
             type=ref,event=pr
@@ -49,7 +58,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           platforms: linux/amd64
           build-args: |
-            APP_VERSION=${{ github.sha }}
+            APP_VERSION=${{ steps.app_version.outputs.value }}
             COMMIT_HASH=${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -74,9 +83,19 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - id: repo
         run: echo "name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+
+      - id: app_version
+        run: |
+          version="$(git describe --tags --exact-match 2>/dev/null || git describe --tags --abbrev=0 2>/dev/null || true)"
+          if [ -z "$version" ]; then
+            version="$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' package.json | head -n 1)"
+          fi
+          echo "value=$version" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v3
 
@@ -93,7 +112,6 @@ jobs:
         with:
           images: ghcr.io/${{ steps.repo.outputs.name }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
             type=sha
             type=ref,event=branch
             type=ref,event=pr
@@ -107,7 +125,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           platforms: linux/arm64
           build-args: |
-            APP_VERSION=${{ github.sha }}
+            APP_VERSION=${{ steps.app_version.outputs.value }}
             COMMIT_HASH=${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -151,7 +169,6 @@ jobs:
         with:
           images: ghcr.io/${{ steps.repo.outputs.name }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
             type=sha
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/release-image-tag.yml
+++ b/.github/workflows/release-image-tag.yml
@@ -1,12 +1,10 @@
-name: Tag Release Image
+name: Promote Release Image
 
 on:
-  release:
-    types: [published, prereleased]
   workflow_dispatch:
     inputs:
       tag:
-        description: Release tag (e.g., v1.0.5)
+        description: Release tag to promote (e.g., v1.8.0)
         required: true
         type: string
 
@@ -15,31 +13,11 @@ permissions:
   packages: write
 
 jobs:
-  tag:
+  promote:
     runs-on: ubuntu-latest
-    env:
-      INPUT_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || '' }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - id: repo
-        run: echo "name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
-
-      - id: tag
-        run: echo "value=${INPUT_TAG:-${GITHUB_REF_NAME:-${{ github.event.release.tag_name }}}}" >> $GITHUB_OUTPUT
-
-      - name: Resolve commit for tag
-        id: sha
-        run: |
-          git fetch --tags --force
-          COMMIT=$(git rev-list -n 1 "${TAG}")
-          SHORT=$(git rev-parse --short=7 "$COMMIT")
-          echo "commit=$COMMIT" >> $GITHUB_OUTPUT
-          echo "short=$SHORT" >> $GITHUB_OUTPUT
-        env:
-          TAG: ${{ steps.tag.outputs.value }}
+        run: echo "name=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v3
 
@@ -50,11 +28,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Retag manifest as release version and latest
+      - name: Promote release manifest as latest
         run: |
-          SRC="ghcr.io/${{ steps.repo.outputs.name }}:sha-${{ steps.sha.outputs.short }}"
-          VER="ghcr.io/${{ steps.repo.outputs.name }}:${{ steps.tag.outputs.value }}"
+          SRC="ghcr.io/${{ steps.repo.outputs.name }}:${{ inputs.tag }}"
           LATEST="ghcr.io/${{ steps.repo.outputs.name }}:latest"
           docker buildx imagetools inspect "$SRC" > /dev/null
-          docker buildx imagetools create -t "$VER" "$SRC"
           docker buildx imagetools create -t "$LATEST" "$SRC"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,10 @@ jobs:
         suite: [admin, api, auth, demo, security, user]
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
@@ -111,6 +115,10 @@ jobs:
         suite: [admin, api, auth, demo, security, user]
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
@@ -141,6 +149,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
       - uses: actions/setup-node@v4
         with:
           node-version: '24'

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -180,11 +180,13 @@ jobs:
         env:
           IMAGE: ghcr.io/${{ needs.release.outputs.repo }}
           TAG: ${{ needs.release.outputs.tag }}
+          LATEST: latest
           AMD64_DIGEST: ${{ needs.release-image-amd64.outputs.digest }}
           ARM64_DIGEST: ${{ needs.release-image-arm64.outputs.digest }}
         run: |
           docker buildx imagetools create \
             -t "${IMAGE}:${TAG}" \
+            -t "${IMAGE}:${LATEST}" \
             "${IMAGE}@${AMD64_DIGEST}" \
             "${IMAGE}@${ARM64_DIGEST}"
 

--- a/packages/api/scripts/install.ts
+++ b/packages/api/scripts/install.ts
@@ -66,6 +66,19 @@ async function install() {
 		adminPort: typeof root?.adminPort === "number" ? root.adminPort : 9081,
 		proxyUi: typeof root?.proxyUi === "boolean" ? root.proxyUi : true,
 	};
+	const defaultOrigin = `http://localhost:${(nextConfig.userPort as number) || 9080}`;
+	nextConfig.publicOrigin =
+		typeof nextConfig.publicOrigin === "string" && nextConfig.publicOrigin.trim().length > 0
+			? nextConfig.publicOrigin
+			: defaultOrigin;
+	nextConfig.issuer =
+		typeof nextConfig.issuer === "string" && nextConfig.issuer.trim().length > 0
+			? nextConfig.issuer
+			: defaultOrigin;
+	nextConfig.rpId =
+		typeof nextConfig.rpId === "string" && nextConfig.rpId.trim().length > 0
+			? nextConfig.rpId
+			: "localhost";
 
 	if (!root || !root.kekPassphrase) {
 		const p = createPrompt();
@@ -100,9 +113,9 @@ async function install() {
 		proxyUi: Boolean(nextConfig.proxyUi),
 		kekPassphrase: (nextConfig.kekPassphrase as string) || "",
 		isDevelopment: process.env.NODE_ENV !== "production",
-		publicOrigin: `http://localhost:${(nextConfig.userPort as number) || 9080}`,
-		issuer: `http://localhost:${(nextConfig.userPort as number) || 9080}`,
-		rpId: "localhost",
+		publicOrigin: (nextConfig.publicOrigin as string) || `http://localhost:${(nextConfig.userPort as number) || 9080}`,
+		issuer: (nextConfig.issuer as string) || `http://localhost:${(nextConfig.userPort as number) || 9080}`,
+		rpId: (nextConfig.rpId as string) || "localhost",
 	};
 
 	const context = await createContext(config);

--- a/packages/api/src/config/loadConfig.test.ts
+++ b/packages/api/src/config/loadConfig.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { loadRootConfig } from "./loadConfig.ts";
+
+test("loadRootConfig returns explicit public/issuer settings from config file", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "darkauth-config-"));
+  const configPath = path.join(dir, "config.yaml");
+  try {
+    fs.writeFileSync(
+      configPath,
+      [
+        "userPort: 8080",
+        "adminPort: 8081",
+        "publicOrigin: https://my.wylde.net",
+        "issuer: https://my.wylde.net",
+        "rpId: my.wylde.net",
+      ].join("\n")
+    );
+
+    const root = loadRootConfig(configPath);
+
+    assert.equal(root.userPort, 8080);
+    assert.equal(root.adminPort, 8081);
+    assert.equal(root.publicOrigin, "https://my.wylde.net");
+    assert.equal(root.issuer, "https://my.wylde.net");
+    assert.equal(root.rpId, "my.wylde.net");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadRootConfig falls back to localhost origin when values missing", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "darkauth-config-"));
+  const configPath = path.join(dir, "config.yaml");
+  try {
+    fs.writeFileSync(configPath, ["userPort: 9000"].join("\n"));
+
+    const root = loadRootConfig(configPath);
+
+    assert.equal(root.publicOrigin, "http://localhost:9000");
+    assert.equal(root.issuer, "http://localhost:9000");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/api/src/config/loadConfig.ts
+++ b/packages/api/src/config/loadConfig.ts
@@ -10,7 +10,18 @@ export type RootConfig = {
   adminPort: number;
   proxyUi: boolean;
   kekPassphrase?: string;
+  publicOrigin?: string;
+  issuer?: string;
+  rpId?: string;
 };
+
+function parseOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function defaultPublicOrigin(userPort: number): string {
+  return `http://localhost:${userPort}`;
+}
 
 function findConfigPath(configFile?: string): string | null {
   // If a specific config file is provided, use it
@@ -44,6 +55,9 @@ export function loadRootConfig(configFile?: string): RootConfig {
       userPort: 9080,
       adminPort: 9081,
       proxyUi: false,
+      publicOrigin: defaultPublicOrigin(9080),
+      issuer: defaultPublicOrigin(9080),
+      rpId: "localhost",
     } as RootConfig;
   }
   const raw = fs.readFileSync(p, "utf8");
@@ -55,8 +69,13 @@ export function loadRootConfig(configFile?: string): RootConfig {
       userPort: 9080,
       adminPort: 9081,
       proxyUi: false,
+      publicOrigin: defaultPublicOrigin(9080),
+      issuer: defaultPublicOrigin(9080),
+      rpId: "localhost",
     } as RootConfig;
   }
+  const userPort = typeof parsed.userPort === "number" ? parsed.userPort : 9080;
+  const adminPort = typeof parsed.adminPort === "number" ? parsed.adminPort : 9081;
   return {
     dbMode: parsed.dbMode === "pglite" ? "pglite" : "remote",
     pgliteDir: typeof parsed.pgliteDir === "string" ? parsed.pgliteDir : undefined,
@@ -64,12 +83,15 @@ export function loadRootConfig(configFile?: string): RootConfig {
       typeof parsed.postgresUri === "string" && parsed.postgresUri.length > 0
         ? parsed.postgresUri
         : "postgresql://DarkAuth:DarkAuth_password@localhost:5432/DarkAuth",
-    userPort: typeof parsed.userPort === "number" ? parsed.userPort : 9080,
-    adminPort: typeof parsed.adminPort === "number" ? parsed.adminPort : 9081,
+    userPort,
+    adminPort,
     proxyUi: typeof parsed.proxyUi === "boolean" ? parsed.proxyUi : false,
     kekPassphrase:
       typeof parsed.kekPassphrase === "string" && parsed.kekPassphrase.length > 0
         ? parsed.kekPassphrase
         : undefined,
+    publicOrigin: parseOptionalString(parsed.publicOrigin) || defaultPublicOrigin(userPort),
+    issuer: parseOptionalString(parsed.issuer) || defaultPublicOrigin(userPort),
+    rpId: parseOptionalString(parsed.rpId) || "localhost",
   } as RootConfig;
 }

--- a/packages/api/src/config/saveConfig.ts
+++ b/packages/api/src/config/saveConfig.ts
@@ -10,6 +10,9 @@ type UpdatableFields = {
   adminPort?: number;
   proxyUi?: boolean;
   kekPassphrase?: string;
+  publicOrigin?: string;
+  issuer?: string;
+  rpId?: string;
 };
 
 function resolveConfigPath(configFile?: string): string {
@@ -48,6 +51,10 @@ export function upsertConfig(updates: UpdatableFields, configFile?: string): voi
   if (typeof updates.proxyUi === "boolean") next.proxyUi = updates.proxyUi;
   if (typeof updates.kekPassphrase === "string" && updates.kekPassphrase.length > 0)
     next.kekPassphrase = updates.kekPassphrase;
+  if (typeof updates.publicOrigin === "string" && updates.publicOrigin.length > 0)
+    next.publicOrigin = updates.publicOrigin;
+  if (typeof updates.issuer === "string" && updates.issuer.length > 0) next.issuer = updates.issuer;
+  if (typeof updates.rpId === "string" && updates.rpId.length > 0) next.rpId = updates.rpId;
   const out = stringify(next);
   // Ensure directory exists before writing
   const dir = path.dirname(p);

--- a/packages/api/src/createServer.ts
+++ b/packages/api/src/createServer.ts
@@ -87,6 +87,8 @@ export async function createServer(initialContext: Context): Promise<AppServer> 
     const chosenPostgresUri = context.services.install?.chosenPostgresUri;
     const userPort = context.config.userPort;
     const adminPort = context.config.adminPort;
+    const publicOrigin = root.publicOrigin || `http://localhost:${userPort}`;
+    const issuer = root.issuer || `http://localhost:${userPort}`;
     const nextConfig: Config = {
       dbMode: hasConfig ? root.dbMode || chosenDbMode || "remote" : chosenDbMode || "pglite",
       pgliteDir: root.pgliteDir || chosenPgliteDir,
@@ -96,9 +98,9 @@ export async function createServer(initialContext: Context): Promise<AppServer> 
       proxyUi: root.proxyUi ?? context.config.proxyUi,
       kekPassphrase: (root.kekPassphrase ?? context.config.kekPassphrase) || "",
       isDevelopment: context.config.isDevelopment,
-      publicOrigin: `http://localhost:${userPort}`,
-      issuer: `http://localhost:${userPort}`,
-      rpId: "localhost",
+      publicOrigin,
+      issuer,
+      rpId: root.rpId || "localhost",
       insecureKeys: context.config.insecureKeys,
       logLevel: context.config.logLevel,
       inInstallMode: !hasConfig,

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -35,6 +35,8 @@ function printStartupPanel(urls: { installUrl?: string; adminUrl: string; userUr
 async function main() {
   const root = loadRootConfig();
   const inInstallMode = !hasConfigFile();
+  const publicOrigin = root.publicOrigin || `http://localhost:${root.userPort}`;
+  const issuer = root.issuer || `http://localhost:${root.userPort}`;
   const config: Config = {
     dbMode: inInstallMode ? "pglite" : root.dbMode || "remote",
     pgliteDir: root.pgliteDir,
@@ -44,9 +46,9 @@ async function main() {
     proxyUi: root.proxyUi,
     kekPassphrase: root.kekPassphrase || "",
     isDevelopment: false,
-    publicOrigin: `http://localhost:${root.userPort}`,
-    issuer: `http://localhost:${root.userPort}`,
-    rpId: "localhost",
+    publicOrigin,
+    issuer,
+    rpId: root.rpId || "localhost",
     inInstallMode,
     logLevel: process.env.DARKAUTH_LOG_LEVEL ?? process.env.LOG_LEVEL,
   };

--- a/packages/api/src/models/authCodes.ts
+++ b/packages/api/src/models/authCodes.ts
@@ -1,5 +1,6 @@
 import { and, eq } from "drizzle-orm";
 import { authCodes } from "../db/schema.ts";
+import { ServerError } from "../errors.ts";
 import type { Context } from "../types.ts";
 
 export async function getAuthCode(context: Context, code: string) {
@@ -28,23 +29,47 @@ export async function createAuthCode(
     drkHash?: string | undefined;
   }
 ) {
-  await context.db.insert(authCodes).values({
-    code: data.code,
-    clientId: data.clientId,
-    userSub: data.userSub,
-    organizationId: data.organizationId ?? null,
-    redirectUri: data.redirectUri,
-    scope: data.scope,
-    nonce: data.nonce ?? null,
-    codeChallenge: data.codeChallenge ?? null,
-    codeChallengeMethod: data.codeChallengeMethod ?? null,
-    expiresAt: data.expiresAt,
-    consumed: false,
-    hasZk: data.hasZk ?? false,
-    zkPubKid: data.zkPubKid ?? null,
-    drkHash: data.drkHash,
-    createdAt: new Date(),
-  });
+  try {
+    await context.db.insert(authCodes).values({
+      code: data.code,
+      clientId: data.clientId,
+      userSub: data.userSub,
+      organizationId: data.organizationId ?? null,
+      redirectUri: data.redirectUri,
+      scope: data.scope,
+      nonce: data.nonce ?? null,
+      codeChallenge: data.codeChallenge ?? null,
+      codeChallengeMethod: data.codeChallengeMethod ?? null,
+      expiresAt: data.expiresAt,
+      consumed: false,
+      hasZk: data.hasZk ?? false,
+      zkPubKid: data.zkPubKid ?? null,
+      drkHash: data.drkHash,
+      createdAt: new Date(),
+    });
+  } catch (error) {
+    if (isAuthCodesSchemaDrift(error)) {
+      throw new ServerError("DarkAuth database schema is out of date; run migrations");
+    }
+    throw error;
+  }
+}
+
+function isAuthCodesSchemaDrift(error: unknown): boolean {
+  for (let current: unknown = error; current; current = getErrorCause(current)) {
+    const candidate = current as { code?: unknown; message?: unknown };
+    const message = typeof candidate.message === "string" ? candidate.message : "";
+    if (candidate.code === "42703" && message.includes("auth_codes")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function getErrorCause(error: unknown): unknown {
+  return error && typeof error === "object" && "cause" in error
+    ? (error as { cause?: unknown }).cause
+    : undefined;
 }
 
 export async function consumeAuthCode(context: Context, code: string): Promise<boolean> {

--- a/packages/api/src/models/authorize.ts
+++ b/packages/api/src/models/authorize.ts
@@ -1,4 +1,5 @@
 import { pendingAuth } from "../db/schema.ts";
+import { ServerError } from "../errors.ts";
 import type { Context } from "../types.ts";
 
 export async function createPendingAuth(
@@ -19,23 +20,51 @@ export async function createPendingAuth(
     expiresAt: Date;
   }
 ) {
-  await context.db.insert(pendingAuth).values({
-    requestId: data.requestId,
-    clientId: data.clientId,
-    redirectUri: data.redirectUri,
-    scope: data.scope,
-    state: data.state,
-    nonce: data.nonce,
-    codeChallenge: data.codeChallenge,
-    codeChallengeMethod: data.codeChallengeMethod,
-    zkPubKid: data.zkPubKid,
-    userSub: data.userSub,
-    organizationId: data.organizationId,
-    origin: data.origin,
-    createdAt: new Date(),
-    expiresAt: data.expiresAt,
-  });
+  try {
+    await context.db.insert(pendingAuth).values({
+      requestId: data.requestId,
+      clientId: data.clientId,
+      redirectUri: data.redirectUri,
+      scope: data.scope,
+      state: data.state,
+      nonce: data.nonce,
+      codeChallenge: data.codeChallenge,
+      codeChallengeMethod: data.codeChallengeMethod,
+      zkPubKid: data.zkPubKid,
+      userSub: data.userSub,
+      organizationId: data.organizationId,
+      origin: data.origin,
+      createdAt: new Date(),
+      expiresAt: data.expiresAt,
+    });
+  } catch (error) {
+    if (isPendingAuthSchemaDrift(error)) {
+      throw new ServerError("DarkAuth database schema is out of date; run migrations");
+    }
+    throw error;
+  }
   return { requestId: data.requestId } as const;
+}
+
+function isPendingAuthSchemaDrift(error: unknown): boolean {
+  for (let current: unknown = error; current; current = getErrorCause(current)) {
+    const candidate = current as { code?: unknown; message?: unknown };
+    const message = typeof candidate.message === "string" ? candidate.message : "";
+    if (
+      candidate.code === "42703" &&
+      message.includes("scope") &&
+      message.includes("pending_auth")
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function getErrorCause(error: unknown): unknown {
+  return error && typeof error === "object" && "cause" in error
+    ? (error as { cause?: unknown }).cause
+    : undefined;
 }
 
 export async function getPendingAuth(context: Context, requestId: string) {

--- a/packages/api/src/models/noncePersistence.test.ts
+++ b/packages/api/src/models/noncePersistence.test.ts
@@ -99,3 +99,37 @@ test("createAuthCode stores nonce in auth code record", async () => {
   assert.equal(insertedValues?.nonce, "nonce-value");
   assert.equal(insertedValues?.scope, "openid profile");
 });
+
+test("createAuthCode explains auth code schema drift", async () => {
+  const context = {
+    db: {
+      insert: () => ({
+        values: () =>
+          Promise.reject({
+            code: "42703",
+            message: 'column "scope" of relation "auth_codes" does not exist',
+          }),
+      }),
+    },
+  } as unknown as Context;
+
+  await assert.rejects(
+    () =>
+      createAuthCode(context, {
+        code: "auth-code",
+        clientId: "client-id",
+        userSub: "user-sub",
+        redirectUri: "https://client.example/callback",
+        scope: "openid profile",
+        codeChallenge: "challenge",
+        codeChallengeMethod: "S256",
+        expiresAt: new Date("2026-02-15T00:00:00.000Z"),
+      }),
+    {
+      name: "AppError",
+      error: "server_error",
+      error_description: "DarkAuth database schema is out of date; run migrations",
+      statusCode: 500,
+    }
+  );
+});

--- a/packages/api/src/models/noncePersistence.test.ts
+++ b/packages/api/src/models/noncePersistence.test.ts
@@ -36,6 +36,40 @@ test("createPendingAuth stores nonce in pending auth record", async () => {
   assert.equal(insertedValues?.scope, "openid profile");
 });
 
+test("createPendingAuth explains pending auth schema drift", async () => {
+  const context = {
+    db: {
+      insert: () => ({
+        values: () =>
+          Promise.reject({
+            code: "42703",
+            message: 'column "scope" of relation "pending_auth" does not exist',
+          }),
+      }),
+    },
+  } as unknown as Context;
+
+  await assert.rejects(
+    () =>
+      createPendingAuth(context, {
+        requestId: "request-id",
+        clientId: "client-id",
+        redirectUri: "https://client.example/callback",
+        scope: "openid profile",
+        codeChallenge: "challenge",
+        codeChallengeMethod: "S256",
+        origin: "https://issuer.example",
+        expiresAt: new Date("2026-02-15T00:00:00.000Z"),
+      }),
+    {
+      name: "AppError",
+      error: "server_error",
+      error_description: "DarkAuth database schema is out of date; run migrations",
+      statusCode: 500,
+    }
+  );
+});
+
 test("createAuthCode stores nonce in auth code record", async () => {
   let insertedValues: Record<string, unknown> | undefined;
 


### PR DESCRIPTION
## Summary
- Handle database schema drift cleanly for both pending_auth and auth_codes writes, returning actionable migration guidance instead of opaque login failures.
- Honor configured publicOrigin, issuer, and rpId values so generated links and issuer metadata use the deployed origin instead of localhost defaults.
- Fix release image tagging so :latest is promoted from release-built images with the tagged app version embedded.
- Harden PR-only visual/brochureware CI checkout so those jobs fetch the PR head SHA directly instead of failing on GitHub synthetic merge-ref checkout.

## Changes
- Added schema-drift detection and regression coverage around pending auth and auth code persistence.
- Loaded and saved public origin, issuer, and RP ID configuration consistently across startup, restart, and install paths.
- Updated Docker/release workflows so main builds no longer overwrite :latest, releases publish both the version tag and latest, and manual latest promotion uses an existing release tag.
- Updated PR screenshot and brochureware jobs to checkout the PR head repository/SHA explicitly.

## Validation
- npm run tidy
- npm run build
- Parsed changed GitHub Actions workflow YAML locally
