### PR TITLE
fix(api,user-ui): apply branding colors to authorize screen

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -100,6 +101,7 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/packages/api/src/http/routers/userRouter.ts
+++ b/packages/api/src/http/routers/userRouter.ts
@@ -147,6 +147,8 @@ export function createUserRouter(context: Context) {
         const lightTextMuted = readColor(c, "textMutedColor", "#9ca3af", "textMuted");
         const lightBorder = readColor(c, "borderColor", "#e5e7eb", "border");
         const lightBg = readColor(c, "backgroundColor", "#f3f4f6", "backgroundGradientStart");
+        const lightCardBg = String(c.cardBackground || "#ffffff");
+        const lightInputBg = String(c.inputBackground || "#ffffff");
         const darkBrand = readColor(cd, "brandColor", "#aec1e0", "primary");
         const darkPrimaryBg = readColor(cd, "primaryBackgroundColor", darkBrand);
         const darkPrimaryHover = readColor(cd, "primaryHoverColor", darkBrand, "primaryHover");
@@ -156,6 +158,8 @@ export function createUserRouter(context: Context) {
         const darkTextMuted = readColor(cd, "textMutedColor", "#9ca3af", "textMuted");
         const darkBorder = readColor(cd, "borderColor", "#374151", "border");
         const darkBg = readColor(cd, "backgroundColor", "#1f2937", "backgroundGradientStart");
+        const darkCardBg = String(cd.cardBackground || "#1f2937");
+        const darkInputBg = String(cd.inputBackground || "#111827");
         const cssVarsLight: Record<string, string> = {
           "--da-page-bg": lightBg,
           "--da-bg-gradient-start": lightBg,
@@ -176,9 +180,9 @@ export function createUserRouter(context: Context) {
           "--da-text-secondary": lightTextSecondary,
           "--da-text-muted": lightTextMuted,
           "--da-border": lightBorder,
-          "--da-card-bg": String(c.cardBackground || "#ffffff"),
+          "--da-card-bg": lightCardBg,
           "--da-card-shadow": String(c.cardShadow || "rgba(0,0,0,0.1)"),
-          "--da-input-bg": String(c.inputBackground || "#ffffff"),
+          "--da-input-bg": lightInputBg,
           "--da-input-border": String(c.inputBorder || lightBorder),
           "--da-input-focus": String(c.inputFocus || lightBrand),
           "--da-font-family": String(f.family || "system-ui, -apple-system, sans-serif"),
@@ -190,10 +194,15 @@ export function createUserRouter(context: Context) {
           "--primary-600": lightPrimaryBg,
           "--primary-700": lightPrimaryHover,
           "--primary-100": lightPrimaryLight,
+          "--primary-button-text": String(c.primaryForegroundColor || "#ffffff"),
           "--gray-900": lightText,
           "--gray-700": lightTextSecondary,
           "--gray-600": lightTextSecondary,
+          "--gray-500": lightTextMuted,
+          "--gray-400": lightBorder,
           "--gray-300": lightBorder,
+          "--gray-200": lightBorder,
+          "--gray-100": lightInputBg,
           "--gray-50": lightBg,
         };
         const cssVarsDark: Record<string, string> = {
@@ -209,9 +218,9 @@ export function createUserRouter(context: Context) {
           "--da-text-secondary": darkTextSecondary,
           "--da-text-muted": darkTextMuted,
           "--da-border": darkBorder,
-          "--da-card-bg": String(cd.cardBackground || "#1f2937"),
+          "--da-card-bg": darkCardBg,
           "--da-card-shadow": String(cd.cardShadow || "rgba(0,0,0,0.3)"),
-          "--da-input-bg": String(cd.inputBackground || "#111827"),
+          "--da-input-bg": darkInputBg,
           "--da-input-border": String(cd.inputBorder || darkBorder),
           "--da-input-focus": String(cd.inputFocus || darkBrand),
           "--da-font-family": String(f.family || "system-ui, -apple-system, sans-serif"),
@@ -223,10 +232,15 @@ export function createUserRouter(context: Context) {
           "--primary-600": darkPrimaryBg,
           "--primary-700": darkPrimaryHover,
           "--primary-100": darkPrimaryLight,
+          "--primary-button-text": String(cd.primaryForegroundColor || "#1f2937"),
           "--gray-900": darkText,
           "--gray-700": darkTextSecondary,
           "--gray-600": darkTextSecondary,
+          "--gray-500": darkTextMuted,
+          "--gray-400": darkBorder,
           "--gray-300": darkBorder,
+          "--gray-200": darkBorder,
+          "--gray-100": darkInputBg,
           "--gray-50": darkBg,
         };
         const varBlock = `:root{${Object.entries(cssVarsLight)

--- a/packages/user-ui/src/App.css
+++ b/packages/user-ui/src/App.css
@@ -596,7 +596,7 @@ body {
 .authorize-app-icon {
   width: 3rem;
   height: 3rem;
-  background: var(--primary-100);
+  background: var(--da-primary-light, var(--primary-100));
   border-radius: var(--radius-md);
   display: flex;
   align-items: center;
@@ -608,12 +608,12 @@ body {
   margin: 0;
   font-size: 1.25rem;
   font-weight: 700;
-  color: var(--gray-900);
+  color: var(--da-text, var(--gray-900));
 }
 
 .authorize-description {
   margin: 0.25rem 0 0;
-  color: var(--gray-600);
+  color: var(--da-text-secondary, var(--gray-600));
   font-size: 0.95rem;
   line-height: 1.4;
   text-align: left;
@@ -624,8 +624,8 @@ body {
   align-items: center;
   gap: 0.75rem;
   padding: 0.75rem 1rem;
-  background: var(--gray-50);
-  border: 1px solid var(--gray-200);
+  background: var(--da-input-bg, var(--gray-50));
+  border: 1px solid var(--da-border, var(--gray-200));
   border-radius: var(--radius-md);
   width: 100%;
   text-align: left;
@@ -634,7 +634,7 @@ body {
 .authorize-avatar {
   width: 2.25rem;
   height: 2.25rem;
-  background: var(--gray-100);
+  background: var(--da-primary-light, var(--gray-100));
   border-radius: 999px;
   display: flex;
   align-items: center;
@@ -655,28 +655,28 @@ body {
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--gray-500);
+  color: var(--da-text-muted, var(--gray-500));
   text-align: left;
 }
 
 .authorize-account-name {
   margin: 0;
   font-weight: 600;
-  color: var(--gray-900);
+  color: var(--da-text, var(--gray-900));
   text-align: left;
 }
 
 .authorize-account-email {
   margin: 0.1rem 0 0;
   font-size: 0.9rem;
-  color: var(--gray-600);
+  color: var(--da-text-secondary, var(--gray-600));
   text-align: left;
 }
 
 .authorize-scopes h3 {
   font-size: 0.85rem;
   font-weight: 600;
-  color: var(--gray-600);
+  color: var(--da-text-secondary, var(--gray-600));
   text-transform: uppercase;
   letter-spacing: 0.08em;
   margin-bottom: 0.75rem;
@@ -697,8 +697,8 @@ body {
   align-items: center;
   gap: 0.75rem;
   padding: 0.75rem 1rem;
-  background: var(--gray-50);
-  border: 1px solid var(--gray-200);
+  background: var(--da-input-bg, var(--gray-50));
+  border: 1px solid var(--da-border, var(--gray-200));
   border-radius: var(--radius-md);
   width: 100%;
   text-align: left;
@@ -707,7 +707,7 @@ body {
 .authorize-scope-icon {
   width: 2rem;
   height: 2rem;
-  background: var(--primary-100);
+  background: var(--da-primary-light, var(--primary-100));
   border-radius: var(--radius-sm);
   display: flex;
   align-items: center;
@@ -729,7 +729,7 @@ body {
 .authorize-scope-name {
   display: block;
   font-weight: 600;
-  color: var(--gray-900);
+  color: var(--da-text, var(--gray-900));
   font-size: 0.95rem;
   text-align: left;
 }
@@ -737,22 +737,22 @@ body {
 .authorize-scope-description {
   display: block;
   font-size: 0.9rem;
-  color: var(--gray-600);
+  color: var(--da-text-secondary, var(--gray-600));
   line-height: 1.4;
   text-align: left;
 }
 
 .authorize-empty {
   margin: 0;
-  color: var(--gray-600);
+  color: var(--da-text-secondary, var(--gray-600));
   font-size: 0.95rem;
 }
 
 .authorize-recovery {
   padding: 1rem;
-  border: 1px solid var(--gray-200);
+  border: 1px solid var(--da-border, var(--gray-200));
   border-radius: var(--radius-md);
-  background: var(--gray-50);
+  background: var(--da-input-bg, var(--gray-50));
 }
 
 .authorize-recovery h3 {
@@ -762,7 +762,7 @@ body {
 
 .authorize-recovery p {
   margin: 0 0 0.75rem;
-  color: var(--gray-600);
+  color: var(--da-text-secondary, var(--gray-600));
   font-size: 0.95rem;
   line-height: 1.5;
 }
@@ -773,7 +773,7 @@ body {
 
 .authorize-footnote {
   font-size: 0.85rem;
-  color: var(--gray-500);
+  color: var(--da-text-muted, var(--gray-500));
   line-height: 1.4;
 }
 
@@ -1033,8 +1033,8 @@ button .loading-spinner {
 }
 
 [data-da-theme="dark"] .header {
-  background: var(--gray-200);
-  border-bottom-color: var(--gray-300);
+  background: var(--da-card-bg);
+  border-bottom-color: var(--da-border, var(--gray-300));
 }
 
 [data-da-theme="dark"] .user-details {
@@ -1052,34 +1052,34 @@ button .loading-spinner {
 }
 
 [data-da-theme="dark"] .authorize-app-icon {
-  background: rgba(96, 165, 250, 0.2);
+  background: var(--da-primary-light, var(--primary-100));
 }
 
 [data-da-theme="dark"] .authorize-account {
-  background: var(--gray-100);
-  border-color: var(--gray-300);
+  background: var(--da-input-bg, var(--gray-100));
+  border-color: var(--da-border, var(--gray-300));
 }
 
 [data-da-theme="dark"] .authorize-avatar {
-  background: var(--gray-200);
+  background: var(--da-primary-light, var(--gray-200));
 }
 
 [data-da-theme="dark"] .authorize-scope-item {
-  background: var(--gray-100);
-  border-color: var(--gray-300);
+  background: var(--da-input-bg, var(--gray-100));
+  border-color: var(--da-border, var(--gray-300));
 }
 
 [data-da-theme="dark"] .authorize-scope-icon {
-  background: rgba(96, 165, 250, 0.2);
+  background: var(--da-primary-light, var(--primary-100));
 }
 
 [data-da-theme="dark"] .authorize-recovery {
-  background: var(--gray-100);
-  border-color: var(--gray-300);
+  background: var(--da-input-bg, var(--gray-100));
+  border-color: var(--da-border, var(--gray-300));
 }
 
 [data-da-theme="dark"] .authorize-footnote {
-  color: var(--gray-600);
+  color: var(--da-text-secondary, var(--gray-600));
 }
 
 [data-da-theme="dark"] .loading-spinner {

--- a/packages/user-ui/src/components/Button.module.css
+++ b/packages/user-ui/src/components/Button.module.css
@@ -22,33 +22,33 @@
 }
 
 .primary {
-  background: var(--primary-600);
+  background: var(--da-primary, var(--primary-600));
   color: var(--primary-button-text, white);
 }
 
 .primary:hover:not(:disabled) {
-  background: var(--primary-700);
+  background: var(--da-primary-hover, var(--primary-700));
 }
 
 .secondary {
   background: transparent;
-  border: 1px solid var(--gray-300);
-  color: var(--gray-700);
+  border: 1px solid var(--da-border, var(--gray-300));
+  color: var(--da-text-secondary, var(--gray-700));
 }
 
 .secondary:hover:not(:disabled) {
-  background: var(--gray-50);
-  border-color: var(--gray-400);
+  background: var(--da-input-bg, var(--gray-50));
+  border-color: var(--da-primary, var(--gray-400));
 }
 
 .success {
-  background: var(--primary-600);
-  border: 1px solid color-mix(in srgb, var(--primary-600) 90%, black);
+  background: var(--da-primary, var(--primary-600));
+  border: 1px solid color-mix(in srgb, var(--da-primary, var(--primary-600)) 90%, black);
   color: var(--primary-button-text, white);
 }
 
 .success:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--primary-600) 90%, white);
+  background: var(--da-primary-hover, color-mix(in srgb, var(--primary-600) 90%, white));
 }
 
 .danger {
@@ -66,32 +66,32 @@
 }
 
 [data-da-theme="dark"] .primary {
-  background: var(--primary-600);
+  background: var(--da-primary, var(--primary-600));
   color: var(--primary-button-text, #1f2937);
 }
 
 [data-da-theme="dark"] .primary:hover:not(:disabled) {
-  background: var(--primary-700);
+  background: var(--da-primary-hover, var(--primary-700));
   color: var(--primary-button-text, #1f2937);
 }
 
 [data-da-theme="dark"] .secondary {
-  border-color: #334155;
-  color: #cbd5e1;
+  border-color: var(--da-border, #334155);
+  color: var(--da-text-secondary, #cbd5e1);
 }
 
 [data-da-theme="dark"] .secondary:hover:not(:disabled) {
-  background: #1f2937;
-  border-color: #475569;
+  background: var(--da-input-bg, #1f2937);
+  border-color: var(--da-primary, #475569);
 }
 
 [data-da-theme="dark"] .success {
-  background: var(--primary-600);
-  border-color: color-mix(in srgb, var(--primary-600) 90%, black);
+  background: var(--da-primary, var(--primary-600));
+  border-color: color-mix(in srgb, var(--da-primary, var(--primary-600)) 90%, black);
 }
 
 [data-da-theme="dark"] .success:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--primary-600) 90%, black);
+  background: var(--da-primary-hover, color-mix(in srgb, var(--primary-600) 90%, black));
 }
 
 [data-da-theme="dark"] .danger {


### PR DESCRIPTION
## Summary
- emit the remaining branded gray/button variables from /api/branding/custom.css
- make the authorize consent UI use the branded --da-* variables for panels, borders, icons, text, and buttons

## Validation
- npm run tidy
- npm run build