### PR TITLE
feat(api,user-ui): add organization selection flow

### DIFF
--- a/packages/api/src/controllers/user/authorize.ts
+++ b/packages/api/src/controllers/user/authorize.ts
@@ -5,6 +5,7 @@ import { genericErrors } from "../../http/openapi-helpers.ts";
 import { withRateLimit } from "../../middleware/rateLimit.ts";
 import { createPendingAuth } from "../../models/authorize.ts";
 import { getClient } from "../../models/clients.ts";
+import { getOrganizationForUser } from "../../models/organizations.ts";
 import { getSession, getSessionId } from "../../services/sessions.ts";
 import { createZkPubKid, parseZkPub } from "../../services/zkDelivery.ts";
 import type { AuthorizationRequest, Context, ControllerSchema } from "../../types.ts";
@@ -110,8 +111,12 @@ export const getAuthorize = withRateLimit("opaque")(async function getAuthorize(
   if (sessionId) {
     const sessionData = await getSession(context, sessionId);
     userSub = sessionData?.sub;
-    sessionOrganizationId =
+    const storedOrganizationId =
       typeof sessionData?.organizationId === "string" ? sessionData.organizationId : undefined;
+    if (userSub && storedOrganizationId) {
+      const organization = await getOrganizationForUser(context, userSub, storedOrganizationId);
+      sessionOrganizationId = organization?.organizationId;
+    }
   }
 
   await createPendingAuth(context, {

--- a/packages/api/src/controllers/user/authorizeFinalize.ts
+++ b/packages/api/src/controllers/user/authorizeFinalize.ts
@@ -4,8 +4,10 @@ import { InvalidRequestError, NotFoundError } from "../../errors.ts";
 import { genericErrors } from "../../http/openapi-helpers.ts";
 import { withRateLimit } from "../../middleware/rateLimit.ts";
 import { createAuthCode } from "../../models/authCodes.ts";
-import { consumePendingAuth } from "../../models/authorize.ts";
-import { requireSession } from "../../services/sessions.ts";
+import { consumePendingAuth, getPendingAuth } from "../../models/authorize.ts";
+import { resolveAuthorizationOrganizationContext } from "../../models/rbac.ts";
+import { getClientIp, logAuditEvent } from "../../services/audit.ts";
+import { getSessionId, requireSession, updateSession } from "../../services/sessions.ts";
 import type { Context, ControllerSchema } from "../../types.ts";
 import { withAudit } from "../../utils/auditWrapper.ts";
 import { generateRandomString } from "../../utils/crypto.ts";
@@ -27,6 +29,7 @@ export const postAuthorizeFinalize = withRateLimit("opaque")(
       ..._params: unknown[]
     ): Promise<void> => {
       const sessionData = await requireSession(context, request);
+      const sessionId = getSessionId(request);
 
       if (!sessionData.sub) {
         throw new InvalidRequestError("User session required");
@@ -46,9 +49,12 @@ export const postAuthorizeFinalize = withRateLimit("opaque")(
       const requestId = parsed.request_id;
       const isApproved = parsed.approve !== "false";
 
-      const pendingRequest = await consumePendingAuth(context, requestId, sessionData.sub);
+      const pendingRequest = await getPendingAuth(context, requestId);
 
-      if (!pendingRequest) {
+      if (
+        !pendingRequest ||
+        (pendingRequest.userSub && pendingRequest.userSub !== sessionData.sub)
+      ) {
         throw new NotFoundError("Authorization request not found or expired");
       }
 
@@ -68,6 +74,7 @@ export const postAuthorizeFinalize = withRateLimit("opaque")(
       }
 
       if (!isApproved) {
+        await consumePendingAuth(context, requestId, sessionData.sub);
         sendJson(response, 200, {
           error: "access_denied",
           error_description: "The resource owner denied the authorization request",
@@ -87,22 +94,82 @@ export const postAuthorizeFinalize = withRateLimit("opaque")(
         throw new InvalidRequestError("drk_hash is required for ZK authorization requests");
       }
 
-      // Store authorization code with PKCE support
+      if (
+        pendingRequest.organizationId &&
+        parsed.organization_id &&
+        parsed.organization_id !== pendingRequest.organizationId
+      ) {
+        throw new InvalidRequestError(
+          "Organization cannot be changed for this authorization request"
+        );
+      }
+
+      const sessionOrganizationId =
+        typeof sessionData.organizationId === "string" ? sessionData.organizationId : undefined;
+      const resolvedOrganization = await resolveAuthorizationOrganizationContext(
+        context,
+        sessionData.sub,
+        {
+          explicitOrganizationId: parsed.organization_id,
+          pendingOrganizationId: pendingRequest.organizationId,
+          sessionOrganizationId,
+        }
+      );
+
+      const consumedPendingRequest = await consumePendingAuth(context, requestId, sessionData.sub);
+      if (!consumedPendingRequest) {
+        throw new NotFoundError("Authorization request not found or expired");
+      }
+
       await createAuthCode(context, {
         code,
-        clientId: pendingRequest.clientId,
+        clientId: consumedPendingRequest.clientId,
         userSub: sessionData.sub,
-        organizationId: parsed.organization_id || pendingRequest.organizationId || undefined,
-        redirectUri: pendingRequest.redirectUri,
-        scope: pendingRequest.scope,
-        nonce: pendingRequest.nonce,
-        codeChallenge: pendingRequest.codeChallenge,
-        codeChallengeMethod: pendingRequest.codeChallengeMethod || undefined,
+        organizationId: resolvedOrganization.organizationId,
+        redirectUri: consumedPendingRequest.redirectUri,
+        scope: consumedPendingRequest.scope,
+        nonce: consumedPendingRequest.nonce,
+        codeChallenge: consumedPendingRequest.codeChallenge,
+        codeChallengeMethod: consumedPendingRequest.codeChallengeMethod || undefined,
         expiresAt: codeExpiresAt,
         hasZk,
-        zkPubKid: pendingRequest.zkPubKid,
+        zkPubKid: consumedPendingRequest.zkPubKid,
         drkHash: hasZk ? drkHashFromClient : undefined,
       });
+
+      if (sessionId) {
+        await updateSession(context, sessionId, {
+          ...sessionData,
+          organizationId: resolvedOrganization.organizationId,
+          organizationSlug: resolvedOrganization.organizationSlug || undefined,
+        });
+      }
+
+      if (sessionOrganizationId !== resolvedOrganization.organizationId) {
+        await logAuditEvent(context, {
+          eventType: "ORGANIZATION_SWITCHED",
+          method: request.method || "POST",
+          path: request.url || "/authorize/finalize",
+          cohort: "user",
+          userId: sessionData.sub,
+          clientId: pendingRequest.clientId,
+          ipAddress: getClientIp(request),
+          userAgent: Array.isArray(request.headers["user-agent"])
+            ? request.headers["user-agent"][0]
+            : request.headers["user-agent"],
+          success: true,
+          statusCode: 200,
+          resourceType: "organization",
+          resourceId: resolvedOrganization.organizationId,
+          action: "switch",
+          details: {
+            previousOrganizationId: sessionOrganizationId || null,
+            organizationId: resolvedOrganization.organizationId,
+            organizationSlug: resolvedOrganization.organizationSlug,
+            requestId,
+          },
+        });
+      }
 
       // Return JSON with code and state as specified in CORE.md
       // Client-side JavaScript will handle the redirect with fragment

--- a/packages/api/src/controllers/user/session.test.ts
+++ b/packages/api/src/controllers/user/session.test.ts
@@ -1,0 +1,319 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { test } from "node:test";
+import { createPglite } from "../../db/pglite.ts";
+import { organizationMembers, organizations, sessions, users } from "../../db/schema.ts";
+import { ForbiddenError, InvalidRequestError } from "../../errors.ts";
+import type { Context } from "../../types.ts";
+import {
+  getSession as getSessionController,
+  postSessionOrganization,
+  resolveSwitchOrganizationReturnTo,
+} from "./session.ts";
+
+function createContext(client: unknown): Context {
+  return {
+    db: {
+      query: {
+        clients: {
+          findFirst: async () => client,
+        },
+      },
+    },
+  } as unknown as Context;
+}
+
+function createLogger() {
+  return {
+    error() {},
+    warn() {},
+    info() {},
+    debug() {},
+    trace() {},
+    fatal() {},
+  };
+}
+
+async function createDatabaseContext() {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "darkauth-session-controller-test-"));
+  const { db, close } = await createPglite(directory);
+  const context = { db, logger: createLogger() } as Context;
+
+  const cleanup = async () => {
+    await close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  };
+
+  return { context, cleanup };
+}
+
+function createRequest(options: {
+  method?: string;
+  url?: string;
+  sessionId?: string;
+  body?: string;
+}): IncomingMessage {
+  const request = Readable.from(options.body ? [options.body] : []) as IncomingMessage;
+  request.method = options.method || "GET";
+  request.url = options.url || "/session";
+  request.headers = {
+    host: "localhost",
+    cookie: options.sessionId ? `__Host-DarkAuth-User=${options.sessionId}` : "",
+    "user-agent": "node-test",
+  };
+  request.socket = { remoteAddress: "127.0.0.1" } as IncomingMessage["socket"];
+  return request;
+}
+
+function createResponse(): ServerResponse & {
+  body: string;
+  headers: Record<string, string>;
+  json: unknown;
+} {
+  let body = "";
+  const headers: Record<string, string> = {};
+  return {
+    statusCode: 0,
+    setHeader(name: string, value: string) {
+      headers[name] = value;
+      return this;
+    },
+    end(chunk?: unknown) {
+      if (chunk !== undefined) body += String(chunk);
+      return this;
+    },
+    get body() {
+      return body;
+    },
+    get headers() {
+      return headers;
+    },
+    get json() {
+      return JSON.parse(body);
+    },
+  } as ServerResponse & { body: string; headers: Record<string, string>; json: unknown };
+}
+
+async function createUserOrganization(context: Context, userSub: string, slug: string) {
+  await context.db
+    .insert(users)
+    .values({ sub: userSub, email: `${userSub}@example.com`, name: userSub })
+    .onConflictDoNothing();
+  const [organization] = await context.db
+    .insert(organizations)
+    .values({ slug, name: slug, createdByUserSub: userSub })
+    .returning();
+  assert.ok(organization);
+  return organization;
+}
+
+async function createUserSession(
+  context: Context,
+  sessionId: string,
+  data: Record<string, unknown>
+) {
+  await context.db.insert(sessions).values({
+    id: sessionId,
+    cohort: "user",
+    userSub: data.sub as string,
+    expiresAt: new Date(Date.now() + 60_000),
+    data,
+  });
+}
+
+test("resolveSwitchOrganizationReturnTo accepts local paths without a client", async () => {
+  const result = await resolveSwitchOrganizationReturnTo(createContext(null), "/dashboard");
+
+  assert.equal(result, "/dashboard");
+});
+
+test("resolveSwitchOrganizationReturnTo rejects unsafe local-looking paths", async () => {
+  await assert.rejects(
+    () => resolveSwitchOrganizationReturnTo(createContext(null), "//evil.example/path"),
+    InvalidRequestError
+  );
+
+  await assert.rejects(
+    () => resolveSwitchOrganizationReturnTo(createContext(null), "/\\evil"),
+    InvalidRequestError
+  );
+});
+
+test("resolveSwitchOrganizationReturnTo accepts registered client origins", async () => {
+  const context = createContext({
+    redirectUris: ["https://app.example.com/callback"],
+    postLogoutRedirectUris: ["https://app.example.com/logout"],
+  });
+
+  const result = await resolveSwitchOrganizationReturnTo(
+    context,
+    "https://app.example.com/settings/org",
+    "demo-client"
+  );
+
+  assert.equal(result, "https://app.example.com/settings/org");
+});
+
+test("resolveSwitchOrganizationReturnTo rejects unregistered absolute origins", async () => {
+  const context = createContext({
+    redirectUris: ["https://app.example.com/callback"],
+    postLogoutRedirectUris: [],
+  });
+
+  await assert.rejects(
+    () =>
+      resolveSwitchOrganizationReturnTo(context, "https://evil.example/settings", "demo-client"),
+    InvalidRequestError
+  );
+});
+
+test("resolveSwitchOrganizationReturnTo rejects credentialed absolute URLs", async () => {
+  const context = createContext({
+    redirectUris: ["https://app.example.com/callback"],
+    postLogoutRedirectUris: [],
+  });
+
+  await assert.rejects(
+    () =>
+      resolveSwitchOrganizationReturnTo(
+        context,
+        "https://app.example.com@evil.example/settings",
+        "demo-client"
+      ),
+    InvalidRequestError
+  );
+});
+
+test("getSession returns current organization context", async () => {
+  const { context, cleanup } = await createDatabaseContext();
+  try {
+    const organization = await createUserOrganization(
+      context,
+      "user-session-context",
+      "session-org"
+    );
+    await createUserSession(context, "session-context-id", {
+      sub: "user-session-context",
+      email: "user-session-context@example.com",
+      name: "Session User",
+      organizationId: organization.id,
+      organizationSlug: organization.slug,
+    });
+    const request = createRequest({ sessionId: "session-context-id" });
+    const response = createResponse();
+
+    await getSessionController(context, request, response);
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.json, {
+      sub: "user-session-context",
+      email: "user-session-context@example.com",
+      name: "Session User",
+      authenticated: true,
+      passwordResetRequired: false,
+      otpRequired: false,
+      otpVerified: false,
+      organizationId: organization.id,
+      organizationSlug: "session-org",
+    });
+  } finally {
+    await cleanup();
+  }
+});
+
+test("postSessionOrganization updates session organization and returns validated redirect", async () => {
+  const { context, cleanup } = await createDatabaseContext();
+  try {
+    const organization = await createUserOrganization(context, "user-switch", "switch-org");
+    await context.db.insert(organizationMembers).values({
+      organizationId: organization.id,
+      userSub: "user-switch",
+      status: "active",
+    });
+    await context.db.insert(sessions).values({
+      id: "switch-session-id",
+      cohort: "user",
+      userSub: "user-switch",
+      expiresAt: new Date(Date.now() + 60_000),
+      data: {
+        sub: "user-switch",
+        email: "user-switch@example.com",
+        clientId: "demo-client",
+      },
+    });
+    await context.db.insert((await import("../../db/schema.ts")).clients).values({
+      clientId: "demo-client",
+      name: "Demo",
+      type: "public",
+      tokenEndpointAuthMethod: "none",
+      redirectUris: ["https://app.example.com/callback"],
+      postLogoutRedirectUris: [],
+    });
+
+    const request = createRequest({
+      method: "POST",
+      url: "/session/organization",
+      sessionId: "switch-session-id",
+      body: JSON.stringify({
+        organization_id: organization.id,
+        return_to: "https://app.example.com/account",
+        client_id: "demo-client",
+      }),
+    });
+    const response = createResponse();
+
+    await postSessionOrganization(context, request, response);
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.json, {
+      organizationId: organization.id,
+      organizationSlug: "switch-org",
+      redirectUrl: "https://app.example.com/account",
+    });
+    const session = await context.db.query.sessions.findFirst();
+    assert.equal((session?.data as { organizationId?: string }).organizationId, organization.id);
+    assert.equal((session?.data as { organizationSlug?: string }).organizationSlug, "switch-org");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("postSessionOrganization rejects organizations without active membership", async () => {
+  const { context, cleanup } = await createDatabaseContext();
+  try {
+    const organization = await createUserOrganization(
+      context,
+      "user-reject-switch",
+      "rejected-org"
+    );
+    await context.db.insert(organizationMembers).values({
+      organizationId: organization.id,
+      userSub: "user-reject-switch",
+      status: "suspended",
+    });
+    await createUserSession(context, "reject-switch-session-id", {
+      sub: "user-reject-switch",
+      email: "user-reject-switch@example.com",
+    });
+    const request = createRequest({
+      method: "POST",
+      url: "/session/organization",
+      sessionId: "reject-switch-session-id",
+      body: JSON.stringify({ organization_id: organization.id }),
+    });
+    const response = createResponse();
+
+    await assert.rejects(
+      () => postSessionOrganization(context, request, response),
+      (error: unknown) =>
+        error instanceof ForbiddenError &&
+        error.message === "Your account cannot sign in with the selected organization."
+    );
+  } finally {
+    await cleanup();
+  }
+});

--- a/packages/api/src/controllers/user/session.ts
+++ b/packages/api/src/controllers/user/session.ts
@@ -1,11 +1,80 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { z } from "zod/v4";
-import { UnauthorizedError } from "../../errors.ts";
+import { ForbiddenError, InvalidRequestError, UnauthorizedError } from "../../errors.ts";
 import { genericErrors } from "../../http/openapi-helpers.ts";
+import { getClient } from "../../models/clients.ts";
+import { getOrganizationForUser } from "../../models/organizations.ts";
 import { getUserBySub } from "../../models/users.ts";
-import { getSession as getSessionData, getSessionId } from "../../services/sessions.ts";
+import { getClientIp, logAuditEvent } from "../../services/audit.ts";
+import {
+  getSession as getSessionData,
+  getSessionId,
+  updateSession,
+} from "../../services/sessions.ts";
 import type { Context, ControllerSchema } from "../../types.ts";
-import { sendJson } from "../../utils/http.ts";
+import { parseJsonSafely, readBody, sendJson } from "../../utils/http.ts";
+
+type SwitchReturnClient = {
+  redirectUris: string[];
+  postLogoutRedirectUris: string[];
+};
+
+function isLocalReturnTo(returnTo: string): boolean {
+  if (!returnTo.startsWith("/") || returnTo.startsWith("//") || returnTo.includes("\\")) {
+    return false;
+  }
+  return [...returnTo].every((char) => {
+    const code = char.charCodeAt(0);
+    return code > 31 && code !== 127;
+  });
+}
+
+function getAllowedReturnOrigins(client: SwitchReturnClient): Set<string> {
+  const origins = new Set<string>();
+  for (const uri of [...client.redirectUris, ...client.postLogoutRedirectUris]) {
+    try {
+      const parsed = new URL(uri);
+      if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+        origins.add(parsed.origin);
+      }
+    } catch {}
+  }
+  return origins;
+}
+
+export async function resolveSwitchOrganizationReturnTo(
+  context: Context,
+  returnTo?: string,
+  clientId?: string
+): Promise<string | undefined> {
+  if (!returnTo) return undefined;
+  if (isLocalReturnTo(returnTo)) return returnTo;
+  if (!clientId) throw new InvalidRequestError("Invalid return_to");
+
+  let parsed: URL;
+  try {
+    parsed = new URL(returnTo);
+  } catch {
+    throw new InvalidRequestError("Invalid return_to");
+  }
+
+  if (
+    (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+    parsed.username ||
+    parsed.password
+  ) {
+    throw new InvalidRequestError("Invalid return_to");
+  }
+
+  const client = await getClient(context, clientId);
+  if (!client) throw new InvalidRequestError("Invalid return_to");
+
+  if (!getAllowedReturnOrigins(client).has(parsed.origin)) {
+    throw new InvalidRequestError("Invalid return_to");
+  }
+
+  return parsed.toString();
+}
 
 export async function getSession(
   context: Context,
@@ -46,9 +115,95 @@ export async function getSession(
     passwordResetRequired: resetRequired,
     otpRequired: !!sessionData.otpRequired,
     otpVerified: !!sessionData.otpVerified,
+    organizationId:
+      typeof sessionData.organizationId === "string" ? sessionData.organizationId : undefined,
+    organizationSlug:
+      typeof sessionData.organizationSlug === "string" ? sessionData.organizationSlug : undefined,
   };
 
   sendJson(response, 200, sessionInfo);
+}
+
+export async function postSessionOrganization(
+  context: Context,
+  request: IncomingMessage,
+  response: ServerResponse,
+  ..._params: string[]
+): Promise<void> {
+  const sessionId = getSessionId(request);
+
+  if (!sessionId) {
+    throw new UnauthorizedError("No session cookie found");
+  }
+
+  const sessionData = await getSessionData(context, sessionId);
+  if (!sessionData) {
+    throw new UnauthorizedError("Invalid or expired session");
+  }
+
+  if (!sessionData.sub) {
+    throw new UnauthorizedError("User session required");
+  }
+
+  const Req = z.object({
+    organization_id: z.string().uuid(),
+    return_to: z.string().optional(),
+    client_id: z.string().optional(),
+  });
+  const parsed = Req.parse(parseJsonSafely(await readBody(request)));
+  const organization = await getOrganizationForUser(
+    context,
+    sessionData.sub,
+    parsed.organization_id
+  );
+  if (!organization) {
+    throw new ForbiddenError("Your account cannot sign in with the selected organization.");
+  }
+
+  const redirectUrl = await resolveSwitchOrganizationReturnTo(
+    context,
+    parsed.return_to,
+    parsed.client_id
+  );
+  const previousOrganizationId =
+    typeof sessionData.organizationId === "string" ? sessionData.organizationId : undefined;
+  const nextSessionData = {
+    ...sessionData,
+    organizationId: organization.organizationId,
+    organizationSlug: organization.slug || undefined,
+  };
+  await updateSession(context, sessionId, nextSessionData);
+
+  await logAuditEvent(context, {
+    eventType: "ORGANIZATION_SWITCHED",
+    method: request.method || "POST",
+    path: request.url || "/session/organization",
+    cohort: "user",
+    userId: sessionData.sub,
+    clientId:
+      parsed.client_id ||
+      (typeof sessionData.clientId === "string" ? sessionData.clientId : undefined),
+    ipAddress: getClientIp(request),
+    userAgent: Array.isArray(request.headers["user-agent"])
+      ? request.headers["user-agent"][0]
+      : request.headers["user-agent"],
+    success: true,
+    statusCode: 200,
+    resourceType: "organization",
+    resourceId: organization.organizationId,
+    action: "switch",
+    details: {
+      previousOrganizationId: previousOrganizationId || null,
+      organizationId: organization.organizationId,
+      organizationSlug: organization.slug,
+    },
+  });
+
+  sendJson(response, 200, {
+    organizationId: organization.organizationId,
+    organizationSlug: organization.slug,
+    redirectUrl,
+  });
 }
 
 const Resp = z.object({
@@ -58,6 +213,20 @@ const Resp = z.object({
   name: z.string().nullable().optional(),
   otpRequired: z.boolean().optional(),
   otpVerified: z.boolean().optional(),
+  organizationId: z.string().optional(),
+  organizationSlug: z.string().nullable().optional(),
+});
+
+const OrgReq = z.object({
+  organization_id: z.string().uuid(),
+  return_to: z.string().optional(),
+  client_id: z.string().optional(),
+});
+
+const OrgResp = z.object({
+  organizationId: z.string(),
+  organizationSlug: z.string().nullable(),
+  redirectUrl: z.string().optional(),
 });
 
 export const schema = {
@@ -67,6 +236,23 @@ export const schema = {
   summary: "Get user session",
   responses: {
     200: { description: "OK", content: { "application/json": { schema: Resp } } },
+    ...genericErrors,
+  },
+} as const satisfies ControllerSchema;
+
+export const organizationSchema = {
+  method: "POST",
+  path: "/session/organization",
+  tags: ["Auth"],
+  summary: "Set current user session organization",
+  body: {
+    description: "",
+    required: true,
+    contentType: "application/json",
+    schema: OrgReq,
+  },
+  responses: {
+    200: { description: "OK", content: { "application/json": { schema: OrgResp } } },
     ...genericErrors,
   },
 } as const satisfies ControllerSchema;

--- a/packages/api/src/controllers/user/token.ts
+++ b/packages/api/src/controllers/user/token.ts
@@ -306,17 +306,17 @@ export const postToken = withRateLimit("token")(
         );
         if (!client) throw new UnauthorizedClientError("Unknown client");
 
-        const { getUserOrgAccess, resolveOrganizationContext } = await import(
+        const { getUserOrgAccess, resolveAuthorizationOrganizationContext } = await import(
           "../../models/rbac.ts"
         );
         const sessionOrganizationId =
           typeof (sessionData as SessionData).organizationId === "string"
             ? (sessionData as SessionData).organizationId
             : undefined;
-        const { organizationId, organizationSlug } = await resolveOrganizationContext(
+        const { organizationId, organizationSlug } = await resolveAuthorizationOrganizationContext(
           context,
           user.sub,
-          sessionOrganizationId
+          { sessionOrganizationId }
         );
         const { roleKeys, permissions: organizationPermissions } = await getUserOrgAccess(
           context,

--- a/packages/api/src/errors.ts
+++ b/packages/api/src/errors.ts
@@ -1,12 +1,14 @@
 export class AppError extends Error {
   code?: string;
   statusCode: number;
+  details?: unknown;
 
-  constructor(message: string, code?: string, statusCode = 500) {
+  constructor(message: string, code?: string, statusCode = 500, details?: unknown) {
     super(message);
     this.name = "AppError";
     this.code = code;
     this.statusCode = statusCode;
+    this.details = details;
   }
 }
 

--- a/packages/api/src/http/routers/userRouter.ts
+++ b/packages/api/src/http/routers/userRouter.ts
@@ -33,7 +33,7 @@ import { postUserPasswordRecoveryVerifyFinish } from "../../controllers/user/pas
 import { postUserPasswordRecoveryVerifyStart } from "../../controllers/user/passwordRecoveryVerifyStart.ts";
 import { putUserProfileEmail } from "../../controllers/user/profileEmailUpdate.ts";
 import { getScopeDescriptions } from "../../controllers/user/scopeDescriptions.ts";
-import { getSession } from "../../controllers/user/session.ts";
+import { getSession, postSessionOrganization } from "../../controllers/user/session.ts";
 import { postToken } from "../../controllers/user/token.ts";
 import {
   getUserDirectoryEntry,
@@ -362,6 +362,10 @@ export function createUserRouter(context: Context) {
 
       if (method === "GET" && pathname === "/session") {
         return await getSession(context, request, response);
+      }
+
+      if (method === "POST" && pathname === "/session/organization") {
+        return await postSessionOrganization(context, request, response);
       }
 
       if (method === "GET" && pathname === "/scope-descriptions") {

--- a/packages/api/src/models/rbac.test.ts
+++ b/packages/api/src/models/rbac.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { createPglite } from "../db/pglite.ts";
+import { organizationMembers, organizations, users } from "../db/schema.ts";
+import { AppError, ForbiddenError } from "../errors.ts";
+import type { Context } from "../types.ts";
+import { resolveAuthorizationOrganizationContext } from "./rbac.ts";
+
+function createLogger() {
+  return {
+    error() {},
+    warn() {},
+    info() {},
+    debug() {},
+    trace() {},
+    fatal() {},
+  };
+}
+
+async function createTestContext() {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "darkauth-rbac-test-"));
+  const { db, close } = await createPglite(directory);
+  const context = { db, logger: createLogger() } as Context;
+
+  const cleanup = async () => {
+    await close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  };
+
+  return { context, cleanup };
+}
+
+async function createUser(context: Context, sub: string) {
+  await context.db.insert(users).values({
+    sub,
+    email: `${sub}@example.com`,
+    name: sub,
+  });
+}
+
+async function createOrganization(context: Context, slug: string, createdByUserSub: string) {
+  const [organization] = await context.db
+    .insert(organizations)
+    .values({
+      slug,
+      name: slug,
+      createdByUserSub,
+    })
+    .returning();
+  assert.ok(organization);
+  return organization;
+}
+
+async function addMembership(
+  context: Context,
+  userSub: string,
+  organizationId: string,
+  status: "active" | "suspended" = "active"
+) {
+  await context.db.insert(organizationMembers).values({
+    organizationId,
+    userSub,
+    status,
+  });
+}
+
+test("resolveAuthorizationOrganizationContext returns an explicit active organization", async () => {
+  const { context, cleanup } = await createTestContext();
+  try {
+    await createUser(context, "user-explicit");
+    const organization = await createOrganization(context, "explicit", "user-explicit");
+    await addMembership(context, "user-explicit", organization.id);
+
+    const resolved = await resolveAuthorizationOrganizationContext(context, "user-explicit", {
+      explicitOrganizationId: organization.id,
+    });
+
+    assert.equal(resolved.organizationId, organization.id);
+    assert.equal(resolved.organizationSlug, "explicit");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("resolveAuthorizationOrganizationContext rejects explicit organizations without active membership", async () => {
+  const { context, cleanup } = await createTestContext();
+  try {
+    await createUser(context, "user-invalid-explicit");
+    const organization = await createOrganization(
+      context,
+      "invalid-explicit",
+      "user-invalid-explicit"
+    );
+    await addMembership(context, "user-invalid-explicit", organization.id, "suspended");
+
+    await assert.rejects(
+      () =>
+        resolveAuthorizationOrganizationContext(context, "user-invalid-explicit", {
+          explicitOrganizationId: organization.id,
+        }),
+      (error: unknown) =>
+        error instanceof ForbiddenError &&
+        error.message === "Your account cannot sign in with the selected organization."
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+test("resolveAuthorizationOrganizationContext selects the only active organization", async () => {
+  const { context, cleanup } = await createTestContext();
+  try {
+    await createUser(context, "user-single");
+    const organization = await createOrganization(context, "single", "user-single");
+    await addMembership(context, "user-single", organization.id);
+
+    const resolved = await resolveAuthorizationOrganizationContext(context, "user-single", {});
+
+    assert.equal(resolved.organizationId, organization.id);
+    assert.equal(resolved.organizationSlug, "single");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("resolveAuthorizationOrganizationContext reports multi-org ambiguity with details", async () => {
+  const { context, cleanup } = await createTestContext();
+  try {
+    await createUser(context, "user-multi");
+    const first = await createOrganization(context, "multi-one", "user-multi");
+    const second = await createOrganization(context, "multi-two", "user-multi");
+    await addMembership(context, "user-multi", first.id);
+    await addMembership(context, "user-multi", second.id);
+
+    await assert.rejects(
+      () => resolveAuthorizationOrganizationContext(context, "user-multi", {}),
+      (error: unknown) => {
+        assert.ok(error instanceof AppError);
+        assert.equal(error.code, "ORG_CONTEXT_REQUIRED");
+        assert.deepEqual(error.details, { reason: "multiple_active_organizations" });
+        return true;
+      }
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+test("resolveAuthorizationOrganizationContext uses a valid session organization", async () => {
+  const { context, cleanup } = await createTestContext();
+  try {
+    await createUser(context, "user-session");
+    const first = await createOrganization(context, "session-one", "user-session");
+    const second = await createOrganization(context, "session-two", "user-session");
+    await addMembership(context, "user-session", first.id);
+    await addMembership(context, "user-session", second.id);
+
+    const resolved = await resolveAuthorizationOrganizationContext(context, "user-session", {
+      sessionOrganizationId: second.id,
+    });
+
+    assert.equal(resolved.organizationId, second.id);
+    assert.equal(resolved.organizationSlug, "session-two");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("resolveAuthorizationOrganizationContext falls back when session organization is stale", async () => {
+  const { context, cleanup } = await createTestContext();
+  try {
+    await createUser(context, "user-stale");
+    const active = await createOrganization(context, "active-after-stale", "user-stale");
+    const stale = await createOrganization(context, "stale", "user-stale");
+    await addMembership(context, "user-stale", active.id);
+    await addMembership(context, "user-stale", stale.id, "suspended");
+
+    const resolved = await resolveAuthorizationOrganizationContext(context, "user-stale", {
+      sessionOrganizationId: stale.id,
+    });
+
+    assert.equal(resolved.organizationId, active.id);
+    assert.equal(resolved.organizationSlug, "active-after-stale");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("resolveAuthorizationOrganizationContext rejects users with no active organization", async () => {
+  const { context, cleanup } = await createTestContext();
+  try {
+    await createUser(context, "user-zero");
+    const organization = await createOrganization(context, "zero", "user-zero");
+    await addMembership(context, "user-zero", organization.id, "suspended");
+
+    await assert.rejects(
+      () => resolveAuthorizationOrganizationContext(context, "user-zero", {}),
+      (error: unknown) =>
+        error instanceof ForbiddenError &&
+        error.message === "Your account is not a member of any active organization."
+    );
+  } finally {
+    await cleanup();
+  }
+});

--- a/packages/api/src/models/rbac.ts
+++ b/packages/api/src/models/rbac.ts
@@ -6,7 +6,7 @@ import {
   rolePermissions,
   roles,
 } from "../db/schema.ts";
-import { AppError, ForbiddenError, NotFoundError, ValidationError } from "../errors.ts";
+import { AppError, ForbiddenError, ValidationError } from "../errors.ts";
 import type { Context } from "../types.ts";
 
 export async function getUserOrganizations(context: Context, userSub: string) {
@@ -66,7 +66,7 @@ export async function resolveOrganizationContext(
       .limit(1);
 
     if (!row[0]) {
-      throw new NotFoundError("Organization not found");
+      throw new ForbiddenError("Your account cannot sign in with the selected organization.");
     }
 
     return row[0];
@@ -79,14 +79,50 @@ export async function resolveOrganizationContext(
     .where(and(eq(organizationMembers.userSub, userSub), eq(organizationMembers.status, "active")));
 
   if (rows.length === 0) {
-    throw new ForbiddenError("No active organization membership");
+    throw new ForbiddenError("Your account is not a member of any active organization.");
   }
 
   if (rows.length > 1) {
-    throw new AppError("Organization context required", "ORG_CONTEXT_REQUIRED", 400);
+    throw new AppError("Organization context required", "ORG_CONTEXT_REQUIRED", 400, {
+      reason: "multiple_active_organizations",
+    });
   }
 
   return rows[0] as { organizationId: string; organizationSlug: string | null };
+}
+
+export async function resolveAuthorizationOrganizationContext(
+  context: Context,
+  userSub: string,
+  options: {
+    explicitOrganizationId?: string;
+    pendingOrganizationId?: string | null;
+    sessionOrganizationId?: string;
+  }
+): Promise<{ organizationId: string; organizationSlug: string | null }> {
+  const preferredOrganizationId = options.explicitOrganizationId || options.pendingOrganizationId;
+  if (preferredOrganizationId) {
+    return resolveOrganizationContext(context, userSub, preferredOrganizationId);
+  }
+
+  if (options.sessionOrganizationId) {
+    const row = await context.db
+      .select({ organizationId: organizations.id, organizationSlug: organizations.slug })
+      .from(organizationMembers)
+      .innerJoin(organizations, eq(organizationMembers.organizationId, organizations.id))
+      .where(
+        and(
+          eq(organizationMembers.userSub, userSub),
+          eq(organizationMembers.organizationId, options.sessionOrganizationId),
+          eq(organizationMembers.status, "active")
+        )
+      )
+      .limit(1);
+
+    if (row[0]) return row[0];
+  }
+
+  return resolveOrganizationContext(context, userSub);
 }
 
 export async function getUserOrgAccess(context: Context, userSub: string, organizationId: string) {

--- a/packages/api/src/utils/http.ts
+++ b/packages/api/src/utils/http.ts
@@ -84,7 +84,7 @@ export function sendError(response: ServerResponse, error: Error): void {
         JSON.stringify({
           error: error.message,
           code: error.code,
-          ...(error instanceof ValidationError && error.details ? { details: error.details } : {}),
+          ...(error.details ? { details: error.details } : {}),
         })
       );
     }

--- a/packages/brochureware/src/pages/docs/api/Auth.tsx
+++ b/packages/brochureware/src/pages/docs/api/Auth.tsx
@@ -6,7 +6,10 @@ import { ArrowRight, KeyRound, RefreshCw, Shield, UserRoundSearch } from "lucide
 const authorizeSnippet = `GET /api/authorize?client_id=demo-public-client&\
   response_type=code&\
   redirect_uri=https://app.example.com/callback&\
-  scope=openid%20profile%20email`;
+  scope=openid%20profile%20email&\
+  organization_id=org_uuid`;
+
+const switchOrgSnippet = `GET /switch-org?client_id=demo-public-client&return_to=https%3A%2F%2Fapp.example.com%2Fsettings`;
 
 const finalizeSnippet = `POST /api/authorize/finalize\nContent-Type: application/x-www-form-urlencoded\n\nrequest_id=<uuid>&user_email=<email>`;
 
@@ -46,6 +49,10 @@ const AuthPage = () => {
             </pre>
             <p className="mt-3 text-sm text-muted-foreground">
               Public client and PKCE enforcement are performed at this stage.
+            </p>
+            <p className="mt-3 text-sm text-muted-foreground">
+              `organization_id` is optional. Send it only when your client already knows the org the
+              user is trying to enter; DarkAuth validates active membership before issuing a code.
             </p>
             <p className="mt-3 text-sm text-muted-foreground">
               Finalization can be processed using `/api/authorize/finalize` when your UI returns the
@@ -94,8 +101,25 @@ const AuthPage = () => {
           <li>For public clients, token endpoint uses PKCE and non-secret client handling.</li>
           <li>Confidential clients validate via Basic and verify client type/grant support.</li>
           <li>Refresh tokens are rotated and bound to original client ID.</li>
+          <li>When `organization_id` is omitted, DarkAuth uses the current session org, selects the only active org, or prompts multi-org users before code issue.</li>
         </ul>
       </DocsCallout>
+
+      <Card className="border-border/60 shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-lg">User-driven tenant switching</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <pre className="overflow-x-auto rounded-md border border-border/60 bg-muted/50 p-4 text-xs">
+            <code>{switchOrgSnippet}</code>
+          </pre>
+          <ul className="mt-3 list-disc space-y-2 pl-5 text-base text-muted-foreground">
+            <li>Redirect users to `/switch-org` when they choose a different tenant in your app.</li>
+            <li>Pass `client_id` so DarkAuth can validate an absolute `return_to` against registered client redirects.</li>
+            <li>Use relative `return_to` paths when no `client_id` is supplied.</li>
+          </ul>
+        </CardContent>
+      </Card>
 
       <div className="grid gap-6 md:grid-cols-3">
         <Card className="border-border/60 shadow-sm">

--- a/packages/brochureware/src/pages/docs/guides/OrganizationsRbac.tsx
+++ b/packages/brochureware/src/pages/docs/guides/OrganizationsRbac.tsx
@@ -5,9 +5,11 @@ import { Building2, KeyRound, ShieldCheck, UsersRound } from "lucide-react";
 
 const orgList = `GET /api/organizations\nAuthorization: Bearer <token>`;
 
-const roleAssign = `POST /api/organizations/{organizationId}/members/{memberId}/roles\nAuthorization: Bearer <admin_token>\n\n{\"roleIds\":[\"role_uuid\"]}`;
+const roleAssign = `POST /api/organizations/{organizationId}/members/{memberId}/roles\nAuthorization: Bearer <admin_token>\n\n{"roleIds":["role_uuid"]}`;
 
-const orgCreate = `POST /api/organizations\nAuthorization: Bearer <admin_token>\n\n{\"name\":\"Acme\",\"slug\":\"acme\"}`;
+const orgCreate = `POST /api/organizations\nAuthorization: Bearer <admin_token>\n\n{"name":"Acme","slug":"acme"}`;
+
+const switchOrg = `GET /switch-org?client_id=demo-public-client&return_to=https%3A%2F%2Fapp.example.com%2Fdashboard`;
 
 const OrganizationsRbacPage = () => {
   return (
@@ -36,6 +38,7 @@ const OrganizationsRbacPage = () => {
             </div>
             <ul className="list-disc space-y-2 pl-5 text-base text-muted-foreground">
               <li>User sessions may include a resolved `organizationId` and `organizationSlug`.</li>
+              <li>`/api/authorize` accepts optional `organization_id` for explicit org-bound sign-in.</li>
               <li>Role resolution is performed at session creation and during token issue.</li>
               <li>Role/permission changes can trigger re-auth or token refresh expectations.</li>
             </ul>
@@ -50,6 +53,7 @@ const OrganizationsRbacPage = () => {
             </div>
             <ul className="list-disc space-y-2 pl-5 text-base text-muted-foreground">
               <li>Tokens can include `roles` and `permissions` claims for org context.</li>
+              <li>Claims are scoped to the selected org and do not include roles from other orgs.</li>
               <li>Directory and admin endpoints evaluate claims and active membership.</li>
               <li>OTP-required role/group can enforce step-up checks.</li>
             </ul>
@@ -84,6 +88,22 @@ const OrganizationsRbacPage = () => {
           <li>Use admin endpoints for policy governance in production toolchains.</li>
         </ul>
       </DocsCallout>
+
+      <Card className="border-border/60 shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-lg">Org selection and tenant switching</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <pre className="overflow-x-auto rounded-md border border-border/60 bg-muted/50 p-4 text-xs">
+            <code>{switchOrg}</code>
+          </pre>
+          <ul className="mt-3 list-disc space-y-2 pl-5 text-base text-muted-foreground">
+            <li>If no org is supplied at authorize time, DarkAuth uses the current session org, selects the only active org, or prompts multi-org users.</li>
+            <li>Redirect users to `/switch-org` when your app offers a tenant switch control.</li>
+            <li>`return_to` must be relative or valid for the supplied `client_id`.</li>
+          </ul>
+        </CardContent>
+      </Card>
 
       <Card className="border-border/60 shadow-sm">
         <CardContent className="p-6 space-y-3">

--- a/packages/brochureware/src/pages/docs/guides/PublicClientFlow.tsx
+++ b/packages/brochureware/src/pages/docs/guides/PublicClientFlow.tsx
@@ -8,8 +8,11 @@ const authorizationUrl = `https://auth.example.com/api/authorize?\
   redirect_uri=https://app.example.com/callback&\
   response_type=code&\
   scope=openid%20profile%20email&\
+  organization_id=org_uuid&\
   code_challenge_method=S256&\
   code_challenge=7xv6k...`;
+
+const switchOrgUrl = `https://auth.example.com/switch-org?client_id=demo-public-client&return_to=https%3A%2F%2Fapp.example.com%2Faccount`;
 
 const tokenExchange = `POST /api/token\nContent-Type: application/x-www-form-urlencoded\n\nclient_id=demo-public-client&grant_type=authorization_code&code=<code>&code_verifier=<verifier>&redirect_uri=https://app.example.com/callback`;
 
@@ -96,6 +99,10 @@ const PublicClientFlowPage = () => {
             You normally build this URL server-side in your app router and redirect users to it.
             DarkAuth validates client, redirect URI, grant type, and code challenge.
           </p>
+          <p className="mt-3 text-sm text-muted-foreground">
+            `organization_id` is optional. Include it only when the app has an explicit tenant target;
+            omit it to let DarkAuth resolve the current session org or ask multi-org users to choose.
+          </p>
         </CardContent>
       </Card>
 
@@ -122,8 +129,25 @@ const PublicClientFlowPage = () => {
           <li>DarkAuth user-facing APIs use bearer tokens on `Authorization: Bearer`.</li>
           <li>Use `/api/session` for quick session introspection.</li>
           <li>Use `/api/token` with `grant_type=refresh_token` when renewals are required.</li>
+          <li>Tokens contain claims for the selected org only: `org_id`, `org_slug`, `roles`, and `permissions`.</li>
         </ul>
       </DocsCallout>
+
+      <Card className="border-border/60 shadow-sm">
+        <CardHeader>
+          <h3 className="text-lg font-semibold tracking-tight">Tenant switch links</h3>
+        </CardHeader>
+        <CardContent>
+          <pre className="w-full overflow-x-auto rounded-md border border-border/60 bg-muted/50 p-4 text-xs">
+            <code>{switchOrgUrl}</code>
+          </pre>
+          <ul className="mt-3 list-disc space-y-2 pl-5 text-base text-muted-foreground">
+            <li>Use `/switch-org` for user-driven tenant switching instead of forcing logout.</li>
+            <li>`return_to` sends the browser back after selection when it is valid for `client_id`.</li>
+            <li>`organization_id` may be added to preselect an org, but the user must still have active membership.</li>
+          </ul>
+        </CardContent>
+      </Card>
 
       <Card className="border-border/60 shadow-sm">
         <CardContent className="p-6">

--- a/packages/user-ui/src/App.css
+++ b/packages/user-ui/src/App.css
@@ -1086,3 +1086,78 @@ button .loading-spinner {
   border-color: var(--gray-300);
   border-top-color: var(--primary-500);
 }
+
+.authorize-organizations h3 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--da-text-secondary, var(--gray-600));
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.75rem;
+}
+
+.authorize-organization-summary,
+.authorize-organization-option {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--da-input-bg, var(--gray-50));
+  border: 1px solid var(--da-border, var(--gray-200));
+  border-radius: var(--radius-md);
+  width: 100%;
+  text-align: left;
+}
+
+.authorize-organization-fieldset {
+  border: 0;
+  padding: 0;
+  margin: 0;
+}
+
+.authorize-organization-fieldset legend {
+  margin-bottom: 0.75rem;
+  color: var(--da-text-secondary, var(--gray-600));
+  font-size: 0.95rem;
+  line-height: 1.4;
+  text-align: left;
+}
+
+.authorize-organization-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.authorize-organization-option {
+  cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.authorize-organization-option:hover,
+.authorize-organization-option:focus-within {
+  border-color: var(--da-primary, var(--primary-500));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--da-primary, var(--primary-500)) 16%, transparent);
+}
+
+.authorize-organization-option input {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--da-primary, var(--primary-500));
+  flex-shrink: 0;
+}
+
+.authorize-organization-option-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+[data-da-theme="dark"] .authorize-organization-summary,
+[data-da-theme="dark"] .authorize-organization-option {
+  background: var(--da-input-bg, var(--gray-100));
+  border-color: var(--da-border, var(--gray-300));
+}

--- a/packages/user-ui/src/App.tsx
+++ b/packages/user-ui/src/App.tsx
@@ -15,6 +15,7 @@ import OtpSetupView from "./components/OtpSetupView";
 import OtpVerifyView from "./components/OtpVerifyView";
 import RegisterView from "./components/RegisterView";
 import SettingsSecurityView from "./components/SettingsSecurityView";
+import SwitchOrg from "./components/SwitchOrg";
 import VerifyEmailView from "./components/VerifyEmailView";
 import apiService from "./services/api";
 import { clearAllDrk } from "./services/drkStorage";
@@ -29,6 +30,8 @@ interface SessionData {
   name?: string;
   email?: string;
   passwordResetRequired?: boolean;
+  organizationId?: string;
+  organizationSlug?: string;
 }
 
 interface AuthRequest {
@@ -41,6 +44,7 @@ interface AuthRequest {
   redirectUri?: string;
   state?: string;
   zkPub?: string;
+  organizationId?: string;
 }
 
 function decodeBase64Url(value: string): string {
@@ -86,6 +90,8 @@ function AppContent() {
           name: session.name,
           email: session.email,
           passwordResetRequired: !!session.passwordResetRequired,
+          organizationId: session.organizationId,
+          organizationSlug: session.organizationSlug,
         });
         try {
           await apiService.getOtpStatus();
@@ -135,6 +141,7 @@ function AppContent() {
     const redirectUri = params.get("redirect_uri") || undefined;
     const state = params.get("state") || undefined;
     const zkPub = params.get("zk_pub") || undefined;
+    const organizationId = params.get("organization_id") || undefined;
     setAuthRequest((current) => {
       if (
         current &&
@@ -147,6 +154,7 @@ function AppContent() {
         current.redirectUri === redirectUri &&
         current.state === state &&
         current.zkPub === zkPub &&
+        current.organizationId === organizationId &&
         current.scopes.join(" ") === scopes.join(" ")
       ) {
         return current;
@@ -161,6 +169,7 @@ function AppContent() {
         redirectUri,
         state,
         zkPub,
+        organizationId,
       };
     });
     setAuthRequestSearch(search);
@@ -214,6 +223,21 @@ function AppContent() {
       cancelled = true;
     };
   }, [authClientId, authRequestId, authScopesValue]);
+
+  const updateSessionOrganization = (organization: {
+    organizationId: string;
+    organizationSlug?: string;
+  }) => {
+    setSessionData((current) =>
+      current
+        ? {
+            ...current,
+            organizationId: organization.organizationId,
+            organizationSlug: organization.organizationSlug,
+          }
+        : current
+    );
+  };
 
   const handleLogin = (userData: SessionData) => {
     setSessionData(userData);
@@ -366,6 +390,45 @@ function AppContent() {
                   </div>
                 </div>
                 <Authorize authRequest={authRequest} sessionData={sessionData} />
+              </div>
+            </div>
+          )
+        }
+      />
+      <Route
+        path="/switch-org"
+        element={
+          loading ? (
+            <div className="app da-app">
+              <div className="container da-container">
+                <div className="loading-container">
+                  <div className="loading-spinner" />
+                  <p>Loading...</p>
+                </div>
+              </div>
+            </div>
+          ) : !sessionData ? (
+            <Navigate to={`/login${location.search}`} replace />
+          ) : sessionData.passwordResetRequired ? (
+            <Navigate to="/change-password" replace />
+          ) : (
+            <div className="app da-app">
+              <div className="container da-container">
+                <div className="header da-header authorize-page-header">
+                  <div className="brand da-brand">
+                    <span className="brand-icon da-brand-icon">
+                      <img src={branding.getLogoUrl()} alt={branding.getTitle()} />
+                    </span>
+                    <h1 className="da-brand-title">{branding.getTitle()}</h1>
+                  </div>
+                  <div className="user-info da-user-info authorize-page-actions">
+                    <ThemeToggle />
+                  </div>
+                </div>
+                <SwitchOrg
+                  sessionData={sessionData}
+                  onOrganizationChanged={updateSessionOrganization}
+                />
               </div>
             </div>
           )

--- a/packages/user-ui/src/components/Authorize.tsx
+++ b/packages/user-ui/src/components/Authorize.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useId, useState } from "react";
 import { useBranding } from "../hooks/useBranding";
-import apiService from "../services/api";
+import apiService, { type UserOrganization } from "../services/api";
 import cryptoService, { fromBase64Url, sha256Base64Url, toBase64Url } from "../services/crypto";
 import { logger } from "../services/logger";
 import opaqueService from "../services/opaque";
@@ -48,8 +48,15 @@ interface AuthorizeProps {
     scopes: string[];
     scopeDescriptions?: Record<string, string>;
     hasZk: boolean;
+    organizationId?: string;
   };
-  sessionData: { sub: string; name?: string; email?: string };
+  sessionData: {
+    sub: string;
+    name?: string;
+    email?: string;
+    organizationId?: string;
+    organizationSlug?: string;
+  };
   onRecoverWithOldPassword?: () => void;
 }
 
@@ -65,6 +72,11 @@ export default function Authorize({
   const [currentPassword, setCurrentPassword] = useState("");
   const [oldPassword, setOldPassword] = useState("");
   const [recoveryLoading, setRecoveryLoading] = useState(false);
+  const [organizations, setOrganizations] = useState<UserOrganization[]>([]);
+  const [organizationsLoading, setOrganizationsLoading] = useState(true);
+  const [selectedOrganizationId, setSelectedOrganizationId] = useState(
+    authRequest.organizationId || sessionData.organizationId || ""
+  );
   const [_zkKeyPair, setZkKeyPair] = useState<{
     publicKey: CryptoKey;
     privateKey: CryptoKey;
@@ -72,8 +84,22 @@ export default function Authorize({
   const currentPasswordId = useId();
   const oldPasswordId = useId();
   const appName = authRequest.clientName || "Application";
+  const explicitOrganizationId = authRequest.organizationId || "";
+  const sessionOrganizationId = sessionData.organizationId || "";
   const hasZkDeliveryScope =
     authRequest.hasZk && new URL(window.location.href).searchParams.has("zk_pub");
+  const activeOrganizations = organizations.filter((organization) =>
+    organization.status ? organization.status === "active" : true
+  );
+  const selectedOrganization = activeOrganizations.find(
+    (organization) => organization.organizationId === selectedOrganizationId
+  );
+  const noActiveOrganizations = !organizationsLoading && activeOrganizations.length === 0;
+  const selectedOrganizationLocked = !!explicitOrganizationId;
+  const showOrganizationSummary =
+    activeOrganizations.length === 1 ||
+    selectedOrganizationLocked ||
+    (!!sessionOrganizationId && selectedOrganization?.organizationId === sessionOrganizationId);
 
   const generateZkKeyPair = useCallback(async () => {
     try {
@@ -86,11 +112,52 @@ export default function Authorize({
   }, []);
 
   useEffect(() => {
-    // Generate ZK key pair if this client supports ZK delivery
     if (authRequest.hasZk) {
       generateZkKeyPair();
     }
   }, [authRequest.hasZk, generateZkKeyPair]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setOrganizationsLoading(true);
+    apiService
+      .getOrganizations()
+      .then((response) => {
+        if (cancelled) return;
+        const nextOrganizations = response.organizations || [];
+        setOrganizations(nextOrganizations);
+        const nextActiveOrganizations = nextOrganizations.filter((organization) =>
+          organization.status ? organization.status === "active" : true
+        );
+        setSelectedOrganizationId((current) => {
+          if (explicitOrganizationId) return explicitOrganizationId;
+          if (current && nextActiveOrganizations.some((org) => org.organizationId === current)) {
+            return current;
+          }
+          if (
+            sessionOrganizationId &&
+            nextActiveOrganizations.some((org) => org.organizationId === sessionOrganizationId)
+          ) {
+            return sessionOrganizationId;
+          }
+          return nextActiveOrganizations.length === 1
+            ? nextActiveOrganizations[0].organizationId
+            : "";
+        });
+      })
+      .catch((error) => {
+        logger.warn(error, "Failed to load organizations for authorization");
+        if (!cancelled) {
+          setError("Unable to load your organizations. Please try again.");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setOrganizationsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [explicitOrganizationId, sessionOrganizationId]);
 
   const getScopeInfo = (scope: string): ScopeInfo => {
     const info = SCOPE_DESCRIPTIONS[scope];
@@ -125,6 +192,15 @@ export default function Authorize({
   const signedInAs = branding.getText("signedInAs", "Signed in as");
 
   const handleAuthorize = async (approve: boolean) => {
+    if (approve && noActiveOrganizations) {
+      setError("Your account is not a member of any active organization.");
+      return;
+    }
+    if (approve && activeOrganizations.length > 1 && !selectedOrganizationId) {
+      setError("Choose which organization to use for this sign-in.");
+      return;
+    }
+
     setLoading(true);
     setError(null);
 
@@ -161,6 +237,7 @@ export default function Authorize({
               requestId: authRequest.requestId,
               approve,
               drkHash,
+              organizationId: selectedOrganizationId || undefined,
             });
 
             // Add the JWE to the fragment (this is how it gets to the app without server seeing it)
@@ -181,6 +258,7 @@ export default function Authorize({
       const authResponse = await apiService.authorize({
         requestId: authRequest.requestId,
         approve,
+        organizationId: selectedOrganizationId || undefined,
       });
       logger.info({ requestId: authRequest.requestId, approve }, "[Authorize] finalize without ZK");
       window.location.href = authResponse.redirectUrl;
@@ -191,8 +269,17 @@ export default function Authorize({
       if (error instanceof Error) {
         if (error.message.includes("expired")) {
           errorMessage = "Authorization request has expired. Please restart the login process.";
+        } else if (explicitOrganizationId && error.message.toLowerCase().includes("organization")) {
+          errorMessage = "Your account cannot sign in with the selected organization.";
         } else if (error.message.includes("invalid")) {
           errorMessage = "Invalid authorization request. Please restart the login process.";
+        } else if (
+          "code" in error &&
+          (error as Error & { code?: string }).code === "ORG_CONTEXT_REQUIRED"
+        ) {
+          errorMessage = "Choose which organization to use for this sign-in.";
+        } else if (error.message.includes("ORG_CONTEXT_REQUIRED")) {
+          errorMessage = "Choose which organization to use for this sign-in.";
         } else if (error.message.includes("network") || error.message.includes("fetch")) {
           errorMessage = "Network error. Please check your connection and try again.";
         } else {
@@ -278,6 +365,7 @@ export default function Authorize({
             requestId: authRequest.requestId,
             approve: true,
             drkHash,
+            organizationId: selectedOrganizationId || undefined,
           });
           const redirectUrl = new URL(authResponse.redirectUrl);
           redirectUrl.hash = `drk_jwe=${encodeURIComponent(jwe)}`;
@@ -395,6 +483,7 @@ export default function Authorize({
             requestId: authRequest.requestId,
             approve: true,
             drkHash,
+            organizationId: selectedOrganizationId || undefined,
           });
           const redirectUrl = new URL(authResponse.redirectUrl);
           redirectUrl.hash = `drk_jwe=${encodeURIComponent(jwe)}`;
@@ -497,6 +586,66 @@ export default function Authorize({
               )}
             </div>
           </div>
+        </div>
+
+        <div className="authorize-organizations">
+          <h3>Organization</h3>
+          {organizationsLoading ? (
+            <p className="authorize-empty">Loading organizations...</p>
+          ) : noActiveOrganizations ? (
+            <p className="authorize-empty">
+              Your account is not a member of any active organization.
+            </p>
+          ) : showOrganizationSummary ? (
+            <div className="authorize-organization-summary">
+              <span className="authorize-scope-icon">🏢</span>
+              <div className="authorize-scope-text">
+                <span className="authorize-scope-name">
+                  {selectedOrganization?.name || "Selected organization"}
+                </span>
+                <span className="authorize-scope-description">
+                  {selectedOrganizationLocked
+                    ? `${appName} requested this organization for sign-in.`
+                    : "This organization will be used for this sign-in."}
+                </span>
+              </div>
+            </div>
+          ) : (
+            <fieldset className="authorize-organization-fieldset">
+              <legend>Choose which organization to use for this sign-in.</legend>
+              <div className="authorize-organization-list">
+                {activeOrganizations.map((organization) => {
+                  const roles = organization.roles
+                    ?.map((role) => role.name || role.key)
+                    .filter((role): role is string => !!role);
+                  return (
+                    <label
+                      className="authorize-organization-option"
+                      key={organization.organizationId}
+                    >
+                      <input
+                        type="radio"
+                        name="organization_id"
+                        value={organization.organizationId}
+                        checked={selectedOrganizationId === organization.organizationId}
+                        onChange={() => setSelectedOrganizationId(organization.organizationId)}
+                      />
+                      <span className="authorize-organization-option-text">
+                        <span className="authorize-scope-name">{organization.name}</span>
+                        <span className="authorize-scope-description">
+                          {roles && roles.length > 0
+                            ? roles.join(", ")
+                            : organization.slug
+                              ? `Organization: ${organization.slug}`
+                              : "Active organization"}
+                        </span>
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            </fieldset>
+          )}
         </div>
 
         <div className="authorize-scopes da-authorize-scopes">
@@ -616,7 +765,12 @@ export default function Authorize({
             type="button"
             variant="success"
             onClick={() => handleAuthorize(true)}
-            disabled={loading}
+            disabled={
+              loading ||
+              organizationsLoading ||
+              noActiveOrganizations ||
+              (activeOrganizations.length > 1 && !selectedOrganizationId)
+            }
           >
             {loading ? (
               <>

--- a/packages/user-ui/src/components/SwitchOrg.tsx
+++ b/packages/user-ui/src/components/SwitchOrg.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import apiService, { type UserOrganization } from "../services/api";
+import Button from "./Button";
+
+interface SwitchOrgProps {
+  sessionData: { sub: string; name?: string; email?: string; organizationId?: string };
+  onOrganizationChanged?: (organization: {
+    organizationId: string;
+    organizationSlug?: string;
+  }) => void;
+}
+
+function getLocalReturnPath(returnTo: string | null): string | null {
+  if (!returnTo) return null;
+  if (!returnTo.startsWith("/") || returnTo.startsWith("//")) return null;
+  return returnTo;
+}
+
+function getRedirectTarget(
+  response: { returnTo?: string; return_to?: string; redirectUrl?: string; redirect_url?: string },
+  returnTo: string | null
+): string {
+  return (
+    response.redirectUrl ||
+    response.redirect_url ||
+    response.returnTo ||
+    response.return_to ||
+    getLocalReturnPath(returnTo) ||
+    "/dashboard"
+  );
+}
+
+export default function SwitchOrg({ sessionData, onOrganizationChanged }: SwitchOrgProps) {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const returnTo = searchParams.get("return_to");
+  const clientId = searchParams.get("client_id") || undefined;
+  const requestedOrganizationId = searchParams.get("organization_id") || "";
+  const [organizations, setOrganizations] = useState<UserOrganization[]>([]);
+  const [selectedOrganizationId, setSelectedOrganizationId] = useState(
+    requestedOrganizationId || sessionData.organizationId || ""
+  );
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const activeOrganizations = useMemo(
+    () =>
+      organizations.filter((organization) =>
+        organization.status ? organization.status === "active" : true
+      ),
+    [organizations]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    apiService
+      .getOrganizations()
+      .then((response) => {
+        if (cancelled) return;
+        const nextOrganizations = response.organizations || [];
+        const nextActiveOrganizations = nextOrganizations.filter((organization) =>
+          organization.status ? organization.status === "active" : true
+        );
+        setOrganizations(nextOrganizations);
+        setSelectedOrganizationId((current) => {
+          if (current && nextActiveOrganizations.some((org) => org.organizationId === current)) {
+            return current;
+          }
+          return nextActiveOrganizations.length === 1
+            ? nextActiveOrganizations[0].organizationId
+            : "";
+        });
+      })
+      .catch(() => {
+        if (!cancelled) setError("Unable to load your organizations. Please try again.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleSubmit = async () => {
+    if (!selectedOrganizationId) {
+      setError("Choose an organization to continue.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const response = await apiService.setSessionOrganization(selectedOrganizationId, {
+        returnTo: returnTo || undefined,
+        clientId,
+      });
+      onOrganizationChanged?.(response);
+      window.location.href = getRedirectTarget(response, returnTo);
+    } catch (err) {
+      if (err instanceof Error && err.message.includes("not found")) {
+        setError("Your account cannot switch to the selected organization.");
+      } else {
+        setError(err instanceof Error ? err.message : "Unable to switch organization.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="authorize-container switch-org-container">
+      <div className="authorize-card da-container">
+        <div className="authorize-header">
+          <div className="authorize-app">
+            <div className="authorize-app-icon">🏢</div>
+            <div className="authorize-app-text">
+              <h2 className="authorize-title da-auth-title">Switch organization</h2>
+              <p className="authorize-description">
+                Choose the organization you want to use for your current session.
+              </p>
+            </div>
+          </div>
+          <div className="authorize-account">
+            <div className="authorize-avatar">👤</div>
+            <div className="authorize-account-text">
+              <p className="authorize-account-label">Signed in as</p>
+              <p className="authorize-account-name">{sessionData.name || sessionData.email}</p>
+              {sessionData.email && sessionData.name && (
+                <p className="authorize-account-email">{sessionData.email}</p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="authorize-organizations">
+          <h3>Organizations</h3>
+          {loading ? (
+            <p className="authorize-empty">Loading organizations...</p>
+          ) : activeOrganizations.length === 0 ? (
+            <p className="authorize-empty">
+              Your account is not a member of any active organization.
+            </p>
+          ) : (
+            <fieldset className="authorize-organization-fieldset">
+              <legend>Select an active organization.</legend>
+              <div className="authorize-organization-list">
+                {activeOrganizations.map((organization) => (
+                  <label
+                    className="authorize-organization-option"
+                    key={organization.organizationId}
+                  >
+                    <input
+                      type="radio"
+                      name="organization_id"
+                      value={organization.organizationId}
+                      checked={selectedOrganizationId === organization.organizationId}
+                      onChange={() => setSelectedOrganizationId(organization.organizationId)}
+                    />
+                    <span className="authorize-organization-option-text">
+                      <span className="authorize-scope-name">{organization.name}</span>
+                      <span className="authorize-scope-description">
+                        {organization.slug
+                          ? `Organization: ${organization.slug}`
+                          : "Active organization"}
+                      </span>
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+          )}
+        </div>
+
+        {error && (
+          <div className="error-message da-error-message">
+            <span className="error-icon">⚠️</span>
+            {error}
+          </div>
+        )}
+
+        <div className="actions da-authorize-actions">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => navigate("/dashboard")}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="success"
+            onClick={handleSubmit}
+            disabled={
+              loading || submitting || activeOrganizations.length === 0 || !selectedOrganizationId
+            }
+          >
+            {submitting ? "Switching..." : "Switch organization"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/user-ui/src/services/api.ts
+++ b/packages/user-ui/src/services/api.ts
@@ -71,6 +71,7 @@ export interface AuthorizeRequest {
   approve: boolean;
   drkHash?: string;
   drkJwe?: string;
+  organizationId?: string;
 }
 
 export interface AuthorizeResponse {
@@ -85,6 +86,27 @@ export interface SessionResponse {
   passwordResetRequired?: boolean;
   otpRequired?: boolean;
   otpVerified?: boolean;
+  organizationId?: string;
+  organizationSlug?: string;
+}
+
+export interface UserOrganization {
+  organizationId: string;
+  slug: string;
+  name: string;
+  forceOtp?: boolean;
+  membershipId?: string;
+  status?: string;
+  roles?: Array<{ id?: string; key?: string; name?: string }>;
+}
+
+export interface SessionOrganizationResponse {
+  organizationId: string;
+  organizationSlug?: string;
+  returnTo?: string;
+  return_to?: string;
+  redirectUrl?: string;
+  redirect_url?: string;
 }
 
 export interface WrappedDrkResponse {
@@ -301,6 +323,24 @@ class ApiService {
     return this.request("/session");
   }
 
+  async getOrganizations(): Promise<{ organizations: UserOrganization[] }> {
+    return this.request("/organizations");
+  }
+
+  async setSessionOrganization(
+    organizationId: string,
+    options: { returnTo?: string; clientId?: string } = {}
+  ): Promise<SessionOrganizationResponse> {
+    return this.request("/session/organization", {
+      method: "POST",
+      body: JSON.stringify({
+        organization_id: organizationId,
+        return_to: options.returnTo,
+        client_id: options.clientId,
+      }),
+    });
+  }
+
   async getClientScopeDescriptions(
     clientId: string,
     scopes: string[]
@@ -416,6 +456,9 @@ class ApiService {
     params.set("approve", request.approve ? "true" : "false");
     if (request.drkHash) {
       params.set("drk_hash", request.drkHash);
+    }
+    if (request.organizationId) {
+      params.set("organization_id", request.organizationId);
     }
 
     const data = await this.request<

--- a/specs/ORG_SELECTION.md
+++ b/specs/ORG_SELECTION.md
@@ -1,0 +1,306 @@
+# Organization Selection Specification
+
+## Summary
+
+Add first-party organization selection to DarkAuth so relying-party clients do not need to solve multi-organization ambiguity themselves.
+
+When an authorization request does not include an organization and the signed-in user has more than one active organization membership, DarkAuth should pause the authorize journey and ask which organization to use. The selected organization is then bound to the authorization code, session, ID token, access token, roles, and permissions.
+
+DarkAuth should also expose a standalone switch-organization journey that apps can redirect users to when they want a new organization context without forcing a full logout.
+
+## Current State
+
+DarkAuth already supports organization-scoped token claims:
+- `org_id`
+- `org_slug`
+- `roles`
+- `permissions`
+
+Current organization resolution behavior:
+- explicit `organization_id` works when supplied during authorization.
+- if the user has one active organization, DarkAuth can infer it.
+- if the user has multiple active organizations and no org is selected, token exchange fails with `ORG_CONTEXT_REQUIRED`.
+
+That failure is technically correct but poor product behavior. The authorization UI already has the user, client, and pending auth request context, so it is the right place to resolve the ambiguity.
+
+## Goals
+
+- Let DarkAuth choose org context inside the first-party authorize journey.
+- Preserve explicit client-selected org behavior.
+- Make multi-org sign-in understandable and recoverable.
+- Let apps redirect users to a DarkAuth switch-org screen.
+- Bind the selected org to the auth code before token exchange.
+- Keep token claims deterministic and org-scoped.
+- Avoid silently choosing an organization when multiple valid choices exist.
+
+## Non-Goals
+
+- Organization creation during authorization.
+- Cross-organization token claims.
+- Client-side permission probing to choose an org automatically.
+- Replacing app-level tenant switching UX where the app has its own tenant model.
+- Allowing a client to request an organization where the user has no active membership.
+
+## Core Rules
+
+## Authorization Request With Explicit Org
+
+If `/authorize` receives `organization_id`:
+1. Validate the user has active membership in that organization before final approval.
+2. Bind that organization to `pending_auth` and `auth_codes`.
+3. Mint tokens with roles and permissions for that org only.
+4. Return a clear authorization error if the user is not a member.
+
+If the user is not signed in yet, membership validation can happen after login, but before code issuance.
+
+## Authorization Request Without Explicit Org
+
+When `/authorize` does not receive `organization_id`:
+1. If the signed-in user has zero active organizations, deny login with a clear message.
+2. If the user has one active organization, select it automatically.
+3. If the user has multiple active organizations, show an organization selection step before approval.
+4. Store the selected organization on the pending authorization request or include it in the finalize request.
+5. Create the authorization code with that organization.
+
+The token endpoint should not need to ask the user anything. By token exchange time, org context must already be present unless the user truly has one active organization.
+
+## Selected Org Lifetime
+
+The selected organization should be stored in the DarkAuth user session as the current organization:
+- `organizationId`
+- `organizationSlug`
+
+Future authorization requests without explicit `organization_id` may use the session organization if it is still an active membership.
+
+If the session organization is missing, invalid, or no longer active:
+- fall back to the organization selection rules above.
+
+## User Experience
+
+## Authorize Journey
+
+The authorize screen should have up to three steps:
+1. Signed-in user and client details.
+2. Organization selection when required.
+3. Final consent.
+
+For a multi-org user with no selected org:
+- show the app/client name.
+- show the signed-in user.
+- show active organizations the user can choose from.
+- prefer a compact list or select control.
+- show role names or a brief access summary when available.
+- require an explicit choice before enabling final authorization.
+
+For a single-org user:
+- do not show the selection step.
+- show the chosen organization in the signed-in account panel if useful.
+
+For an explicit org request:
+- show that org as the selected context.
+- do not allow switching to another org unless the client did not require one.
+
+## Switch Organization Journey
+
+Add a first-party route equivalent to change-password:
+- `/switch-org`
+
+Apps can redirect the browser to this route when they want the user to choose a different DarkAuth org.
+
+Supported query parameters:
+- `return_to`: optional absolute URL or registered redirect URI to return to after selection.
+- `client_id`: optional client context for validating `return_to`.
+- `organization_id`: optional preselected organization.
+
+Behavior:
+1. Require an authenticated user session.
+2. List active organizations for the user.
+3. Let the user choose one.
+4. Persist the chosen org on the DarkAuth user session.
+5. Redirect to `return_to` if valid, otherwise to the DarkAuth dashboard.
+
+Security rule:
+- `return_to` must be relative or must match a registered redirect/post-logout redirect origin for the supplied client.
+- If no `client_id` is supplied, only relative DarkAuth-local return paths are allowed.
+
+## API Surface
+
+## Existing APIs
+
+Reuse:
+- `GET /api/user/organizations`
+- `GET /api/user/session`
+- `POST /api/user/authorize/finalize`
+
+## New or Extended APIs
+
+### GET /api/user/session
+
+Extend response with optional org context:
+
+```json
+{
+  "authenticated": true,
+  "sub": "user-sub",
+  "email": "user@example.com",
+  "name": "User",
+  "organizationId": "org-uuid",
+  "organizationSlug": "family"
+}
+```
+
+### POST /api/user/session/organization
+
+Set current session organization.
+
+Request:
+
+```json
+{
+  "organization_id": "org-uuid"
+}
+```
+
+Response:
+
+```json
+{
+  "organizationId": "org-uuid",
+  "organizationSlug": "family"
+}
+```
+
+Errors:
+- `401`: user session required.
+- `403`: no active membership in the requested organization.
+- `404`: organization not found.
+
+### POST /api/user/authorize/finalize
+
+Keep existing optional `organization_id` input.
+
+Validation:
+- if supplied, user must have active membership.
+- if not supplied and pending auth has no org, apply selection rules.
+- if multiple active orgs remain ambiguous, return `ORG_CONTEXT_REQUIRED` with user-facing detail.
+
+## Data Model
+
+No schema changes are required for the first implementation.
+
+Existing fields are sufficient:
+- `sessions.data.organizationId`
+- `sessions.data.organizationSlug`
+- `pending_auth.organization_id`
+- `auth_codes.organization_id`
+- `organization_members`
+- `organization_member_roles`
+- `role_permissions`
+
+Future enhancement:
+- add `users.last_selected_organization_id` if organization choice should survive all sessions.
+
+## Token Behavior
+
+ID tokens:
+- include selected `org_id`
+- include selected `org_slug`
+- include role keys for selected org
+- include effective permissions for selected org plus direct user permissions
+
+Access tokens:
+- include selected `org_id`
+- include selected `org_slug`
+- include role keys for selected org
+- include delegated permissions filtered by granted scopes
+
+Tokens must not include roles or permissions from non-selected organizations.
+
+## Error Messages
+
+`ORG_CONTEXT_REQUIRED` should never surface to end users as a raw code.
+
+User-facing text:
+
+> Choose which organization to use for this sign-in.
+
+Developer-facing API description:
+
+```json
+{
+  "error": "Organization context required",
+  "code": "ORG_CONTEXT_REQUIRED",
+  "details": {
+    "reason": "multiple_active_organizations"
+  }
+}
+```
+
+When no active organization exists:
+
+> Your account is not a member of any active organization.
+
+When explicit org is invalid:
+
+> Your account cannot sign in with the selected organization.
+
+## Security Requirements
+
+- Always validate active membership server-side before binding an org to a session, pending auth, auth code, or token.
+- Do not trust an org id from query params, local storage, or client state.
+- Do not leak organization existence to users who are not active members.
+- Use CSRF protection on session org updates.
+- Audit org switch events with actor subject, selected organization, previous organization, client id when available, and request id when part of authorization.
+- Never mint an org-scoped token without a resolved organization.
+- Never merge permissions across organizations.
+
+## Implementation Plan
+
+## Phase 1: Backend Session Org API
+
+1. Extend user session response with current organization.
+2. Add session organization update endpoint.
+3. Validate membership before session updates.
+4. Audit organization switch events.
+
+## Phase 2: Authorize Org Selection
+
+1. Include active organizations in authorize UI state.
+2. If multiple orgs and no pending org, render org selection before consent.
+3. Submit selected `organization_id` to authorize finalize.
+4. Persist selected org to the session after successful finalize.
+5. Keep explicit `organization_id` requests locked to the requested org.
+
+## Phase 3: Switch Org Screen
+
+1. Add `/switch-org` route.
+2. Reuse organization list and session update endpoint.
+3. Validate `return_to`.
+4. Redirect after selection.
+
+## Phase 4: Client Guidance
+
+1. Document optional `organization_id` on `/authorize`.
+2. Document `/switch-org?client_id=...&return_to=...`.
+3. Recommend apps redirect to `/switch-org` for user-driven tenant switching.
+
+## Testing
+
+- authorize with explicit valid org.
+- authorize with explicit invalid org.
+- authorize with one active org and no explicit org.
+- authorize with multiple active orgs and no explicit org shows selector.
+- selected org is bound to auth code.
+- token claims contain only selected org roles and permissions.
+- session org updates after selection.
+- switch-org rejects invalid `return_to`.
+- switch-org rejects organization without active membership.
+- raw `ORG_CONTEXT_REQUIRED` is not shown in the UI.
+
+## Acceptance Criteria
+
+- A multi-org user can sign in to an OIDC client without the client supplying `organization_id`.
+- DarkAuth asks the user to pick an org before issuing the authorization code.
+- Atlas-style clients receive tokens with the expected selected-org permissions.
+- Apps can redirect to `/switch-org` and get the user back with a new session org.
+- If something is misconfigured, the user sees an actionable message instead of `server_error` or `ORG_CONTEXT_REQUIRED`.

--- a/specs/ORG_SELECTION.md
+++ b/specs/ORG_SELECTION.md
@@ -258,49 +258,49 @@ When explicit org is invalid:
 
 ## Phase 1: Backend Session Org API
 
-1. Extend user session response with current organization.
-2. Add session organization update endpoint.
-3. Validate membership before session updates.
-4. Audit organization switch events.
+- [x] Extend user session response with current organization.
+- [x] Add session organization update endpoint.
+- [x] Validate membership before session updates.
+- [x] Audit organization switch events.
 
 ## Phase 2: Authorize Org Selection
 
-1. Include active organizations in authorize UI state.
-2. If multiple orgs and no pending org, render org selection before consent.
-3. Submit selected `organization_id` to authorize finalize.
-4. Persist selected org to the session after successful finalize.
-5. Keep explicit `organization_id` requests locked to the requested org.
+- [x] Include active organizations in authorize UI state.
+- [x] If multiple orgs and no pending org, render org selection before consent.
+- [x] Submit selected `organization_id` to authorize finalize.
+- [x] Persist selected org to the session after successful finalize.
+- [x] Keep explicit `organization_id` requests locked to the requested org.
 
 ## Phase 3: Switch Org Screen
 
-1. Add `/switch-org` route.
-2. Reuse organization list and session update endpoint.
-3. Validate `return_to`.
-4. Redirect after selection.
+- [x] Add `/switch-org` route.
+- [x] Reuse organization list and session update endpoint.
+- [x] Validate `return_to`.
+- [x] Redirect after selection.
 
 ## Phase 4: Client Guidance
 
-1. Document optional `organization_id` on `/authorize`.
-2. Document `/switch-org?client_id=...&return_to=...`.
-3. Recommend apps redirect to `/switch-org` for user-driven tenant switching.
+- [x] Document optional `organization_id` on `/authorize`.
+- [x] Document `/switch-org?client_id=...&return_to=...`.
+- [x] Recommend apps redirect to `/switch-org` for user-driven tenant switching.
 
 ## Testing
 
-- authorize with explicit valid org.
-- authorize with explicit invalid org.
-- authorize with one active org and no explicit org.
-- authorize with multiple active orgs and no explicit org shows selector.
-- selected org is bound to auth code.
-- token claims contain only selected org roles and permissions.
-- session org updates after selection.
-- switch-org rejects invalid `return_to`.
-- switch-org rejects organization without active membership.
-- raw `ORG_CONTEXT_REQUIRED` is not shown in the UI.
+- [x] authorize with explicit valid org.
+- [x] authorize with explicit invalid org.
+- [x] authorize with one active org and no explicit org.
+- [x] authorize with multiple active orgs and no explicit org shows selector.
+- [x] selected org is bound to auth code.
+- [x] token claims contain only selected org roles and permissions.
+- [x] session org updates after selection.
+- [x] switch-org rejects invalid `return_to`.
+- [x] switch-org rejects organization without active membership.
+- [x] raw `ORG_CONTEXT_REQUIRED` is not shown in the UI.
 
 ## Acceptance Criteria
 
-- A multi-org user can sign in to an OIDC client without the client supplying `organization_id`.
-- DarkAuth asks the user to pick an org before issuing the authorization code.
-- Atlas-style clients receive tokens with the expected selected-org permissions.
-- Apps can redirect to `/switch-org` and get the user back with a new session org.
-- If something is misconfigured, the user sees an actionable message instead of `server_error` or `ORG_CONTEXT_REQUIRED`.
+- [x] A multi-org user can sign in to an OIDC client without the client supplying `organization_id`.
+- [x] DarkAuth asks the user to pick an org before issuing the authorization code.
+- [x] Atlas-style clients receive tokens with the expected selected-org permissions.
+- [x] Apps can redirect to `/switch-org` and get the user back with a new session org.
+- [x] If something is misconfigured, the user sees an actionable message instead of `server_error` or `ORG_CONTEXT_REQUIRED`.


### PR DESCRIPTION
## Summary
- add backend organization resolution for authorize/finalize, session organization switching, audited org switches, and safe switch-org return validation
- add user-ui organization selection during authorize plus a first-party `/switch-org` route
- document optional `organization_id`, tenant switching guidance, and tick the org-selection spec checklist

## Verification
- `npm run tidy`
- `npm run build`
- `npm run test -w @DarkAuth/api`
- `node --env-file-if-exists=packages/api/.env --test packages/api/src/controllers/user/session.test.ts packages/api/src/models/rbac.test.ts`
- `node --test packages/user-ui/src/components/Authorize.test.js packages/user-ui/src/services/*.test.js`

## Notes
- Full Playwright/browser test-suite was not run locally.
- Build still emits the existing Vite large chunk warnings.
