### PR TITLE
fix(api): align dark branded authorize surfaces

### DIFF
--- a/docs/organization-rbac.md
+++ b/docs/organization-rbac.md
@@ -95,9 +95,12 @@ Roles and role-permission mapping:
 - `POST /admin/roles`
 - `GET /admin/roles/{roleId}`
 - `PUT /admin/roles/{roleId}`
+  - Updates custom and system role metadata.
 - `DELETE /admin/roles/{roleId}`
+  - System roles cannot be deleted.
 - `PUT /admin/roles/{roleId}/permissions`
   - Replaces role permission set with `permissionKeys`.
+  - Supports custom and system roles, including the default member role.
 
 ## Token claim behavior
 

--- a/packages/api/src/http/routers/userRouter.test.ts
+++ b/packages/api/src/http/routers/userRouter.test.ts
@@ -161,6 +161,14 @@ test("user router exposes page background CSS variables for branded user pages",
   assert.match(response.body, /:root\[data-da-theme='dark'\]\{[^}]*--da-page-bg:#0a0b0c/);
   assert.match(
     response.body,
+    /:root\[data-da-theme='dark'\]\{[^}]*--da-card-bg:rgba\(255,255,255,0\.05\)/
+  );
+  assert.match(
+    response.body,
+    /:root\[data-da-theme='dark'\]\{[^}]*--da-input-bg:rgba\(0,0,0,0\.2\)/
+  );
+  assert.match(
+    response.body,
     /@media \(prefers-color-scheme: dark\)\{:root:not\(\[data-da-theme\]\)\{[^}]*--da-page-bg:#0a0b0c/
   );
   assert.match(response.body, /body\{background:linear-gradient\(var\(--da-bg-angle\)/);

--- a/packages/api/src/http/routers/userRouter.ts
+++ b/packages/api/src/http/routers/userRouter.ts
@@ -158,8 +158,8 @@ export function createUserRouter(context: Context) {
         const darkTextMuted = readColor(cd, "textMutedColor", "#9ca3af", "textMuted");
         const darkBorder = readColor(cd, "borderColor", "#374151", "border");
         const darkBg = readColor(cd, "backgroundColor", "#1f2937", "backgroundGradientStart");
-        const darkCardBg = String(cd.cardBackground || "#1f2937");
-        const darkInputBg = String(cd.inputBackground || "#111827");
+        const darkCardBg = String(cd.cardBackground || "rgba(255,255,255,0.05)");
+        const darkInputBg = String(cd.inputBackground || "rgba(0,0,0,0.2)");
         const cssVarsLight: Record<string, string> = {
           "--da-page-bg": lightBg,
           "--da-bg-gradient-start": lightBg,

--- a/packages/api/src/models/rbacAdmin.test.ts
+++ b/packages/api/src/models/rbacAdmin.test.ts
@@ -6,9 +6,17 @@ import {
   addOrganizationMemberRolesAdmin,
   removeOrganizationMemberRoleAdmin,
   setRolePermissionsAdmin,
+  updateRoleAdmin,
 } from "./rbacAdmin.ts";
 
-test("setRolePermissionsAdmin rejects system roles", async () => {
+test("updateRoleAdmin allows system roles", async () => {
+  const updatedRole = {
+    id: "role-1",
+    key: "member",
+    name: "Default Member",
+    description: "Default role",
+    system: true,
+  };
   const context = {
     db: {
       query: {
@@ -16,17 +24,46 @@ test("setRolePermissionsAdmin rejects system roles", async () => {
           findFirst: async () => ({ id: "role-1", system: true }),
         },
       },
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: async () => [updatedRole],
+          }),
+        }),
+      }),
     },
   } as unknown as Context;
 
-  await assert.rejects(
-    () => setRolePermissionsAdmin(context, "role-1", []),
-    (error: unknown) => {
-      assert.ok(error instanceof ValidationError);
-      assert.equal(error.message, "System roles cannot be updated");
-      return true;
-    }
-  );
+  const result = await updateRoleAdmin(context, "role-1", { name: "Default Member" });
+
+  assert.equal(result, updatedRole);
+});
+
+test("setRolePermissionsAdmin allows system roles", async () => {
+  let deleteCalled = false;
+  const context = {
+    db: {
+      query: {
+        roles: {
+          findFirst: async () => ({ id: "role-1", system: true }),
+        },
+      },
+      transaction: async (callback: (trx: unknown) => Promise<void>) => {
+        await callback({
+          delete: () => ({
+            where: () => {
+              deleteCalled = true;
+            },
+          }),
+        });
+      },
+    },
+  } as unknown as Context;
+
+  const result = await setRolePermissionsAdmin(context, "role-1", []);
+
+  assert.equal(deleteCalled, true);
+  assert.deepEqual(result, { roleId: "role-1", permissionKeys: [] });
 });
 
 test("addOrganizationMemberRolesAdmin rejects empty role ids", async () => {

--- a/packages/api/src/models/rbacAdmin.ts
+++ b/packages/api/src/models/rbacAdmin.ts
@@ -621,7 +621,6 @@ export async function updateRoleAdmin(
 ) {
   const existing = await context.db.query.roles.findFirst({ where: eq(roles.id, roleId) });
   if (!existing) throw new NotFoundError("Role not found");
-  if (existing.system) throw new ValidationError("System roles cannot be updated");
 
   const updates: { name?: string; description?: string | null; updatedAt: Date } = {
     updatedAt: new Date(),
@@ -661,7 +660,6 @@ export async function setRolePermissionsAdmin(
 ) {
   const existingRole = await context.db.query.roles.findFirst({ where: eq(roles.id, roleId) });
   if (!existingRole) throw new NotFoundError("Role not found");
-  if (existingRole.system) throw new ValidationError("System roles cannot be updated");
 
   const deduped = Array.from(new Set(permissionKeys));
 

--- a/packages/test-suite/tests/admin/permissions/permissions.spec.ts
+++ b/packages/test-suite/tests/admin/permissions/permissions.spec.ts
@@ -75,6 +75,42 @@ test.describe('Admin - Permissions Management', () => {
     expect(testPerm).toBeTruthy();
   });
 
+  test('Can assign permissions to the default member role via API', async () => {
+    const adminSession = await getAdminSession(servers, adminCred);
+
+    const rolesRes = await fetch(`${servers.adminUrl}/admin/roles`, {
+      headers: {
+        Cookie: adminSession.cookieHeader,
+        'Origin': servers.adminUrl
+      }
+    });
+
+    expect(rolesRes.ok).toBeTruthy();
+    const rolesJson = await rolesRes.json() as {
+      roles: Array<{ id: string; key: string; permissionKeys: string[]; system: boolean }>;
+    };
+    const memberRole = rolesJson.roles.find(role => role.key === 'member');
+    expect(memberRole).toBeTruthy();
+    expect(memberRole?.system).toBeTruthy();
+
+    const permissionKeys = Array.from(new Set([...(memberRole?.permissionKeys || []), 'api:test:read']));
+    const updateRes = await fetch(`${servers.adminUrl}/admin/roles/${memberRole?.id}/permissions`, {
+      method: 'PUT',
+      headers: {
+        Cookie: adminSession.cookieHeader,
+        'Origin': servers.adminUrl,
+        'Content-Type': 'application/json',
+        'x-csrf-token': adminSession.csrfToken,
+      },
+      body: JSON.stringify({ permissionKeys })
+    });
+
+    expect(updateRes.ok).toBeTruthy();
+    const updated = await updateRes.json() as { roleId: string; permissionKeys: string[] };
+    expect(updated.roleId).toBe(memberRole?.id);
+    expect(updated.permissionKeys.includes('api:test:read')).toBeTruthy();
+  });
+
   test('Cannot create duplicate permission', async () => {
     const adminSession = await getAdminSession(servers, adminCred);
 

--- a/packages/user-ui/src/components/Authorize.test.js
+++ b/packages/user-ui/src/components/Authorize.test.js
@@ -25,3 +25,13 @@ test("generateNewKeys copies DRK before clearing it for ZK handoff", () => {
 test("Authorize never posts DRK JWE to finalize", () => {
   assert.equal(source.includes("drkJwe:"), false);
 });
+
+test("multi-organization authorize keeps the organization picker visible", () => {
+  const summaryExpression = source.match(/const showOrganizationSummary = ([^;]+);/);
+
+  assert.ok(summaryExpression);
+  assert.equal(
+    summaryExpression[1],
+    "activeOrganizations.length === 1 || selectedOrganizationLocked"
+  );
+});

--- a/packages/user-ui/src/components/Authorize.tsx
+++ b/packages/user-ui/src/components/Authorize.tsx
@@ -96,10 +96,7 @@ export default function Authorize({
   );
   const noActiveOrganizations = !organizationsLoading && activeOrganizations.length === 0;
   const selectedOrganizationLocked = !!explicitOrganizationId;
-  const showOrganizationSummary =
-    activeOrganizations.length === 1 ||
-    selectedOrganizationLocked ||
-    (!!sessionOrganizationId && selectedOrganization?.organizationId === sessionOrganizationId);
+  const showOrganizationSummary = activeOrganizations.length === 1 || selectedOrganizationLocked;
 
   const generateZkKeyPair = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary
- make generated dark branding CSS use the same near-black card/input fallback surfaces as the login UI
- keep the organization picker visible for multi-org authorize requests even when the session already has a current organization
- allow system roles, including the default member role, to receive permissions through admin role APIs
- update organization RBAC docs for system-role permission editing

## Validation
- node --test packages/user-ui/src/components/Authorize.test.js packages/user-ui/src/services/*.test.js
- npm run test -w @DarkAuth/api -- rbacAdmin.test.ts
- cd packages/test-suite && PW_REPORTER=dot PW_ARTIFACTS=off npx playwright test tests/admin/permissions/permissions.spec.ts --reporter=dot --workers=1
- npm run tidy
- npm run build

## Notes
- `npm run build` still emits the existing Vite large chunk warnings.
