### PR TITLE
feat(api,user-ui): add email password reset flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ DarkAuth is open source and self-hosted. There is no paid plan, subscription, or
 - **OIDC Compatible**: Standard OAuth 2.0/OpenID Connect for universal compatibility
 - **Zero-Knowledge DRK Delivery**: Optional fragment-based JWE delivery for trusted clients
 - **TOTP MFA**: Time-based one-time passwords for users and admins with backup codes, rate limits, and per-organization enforcement
+- **Email Password Reset**: SMTP-gated self-service reset links with hashed one-time tokens and session invalidation
 - **Database-Backed Configuration**: Most settings stored in PostgreSQL; minimal `config.yaml` for bootstrap
 - **Two-Port Architecture**: Separate ports for user (9080) and admin (9081). First-run installer is served on the admin port until setup completes.
 - **Secure Key Storage**: Optional encryption of private keys at rest using Argon2id-derived KEK
@@ -171,6 +172,7 @@ All configuration and state stored in PostgreSQL:
 - **wrapped_root_keys**: Encrypted DRK storage
 - **auth_codes**: Authorization codes
 - **sessions**: Active sessions
+- **password_reset_tokens**: HMAC-hashed, single-use email password reset tokens
 - **otp_configs / otp_backup_codes**: OTP configuration and backup codes
 - **pending_auth**: In-progress auth requests
 - **admin_users**: Admin accounts (separate cohort)
@@ -252,6 +254,12 @@ Authorization codes are short-lived and single-use. Redemption at the token endp
 - `POST /api/opaque/login/start`
 - `POST /api/opaque/login/finish`
 
+### Email Password Reset
+- `POST /api/password/reset/request` - Request reset email with generic anti-enumeration response
+- `GET /api/password/reset/token?token=...` - Validate reset link and return only masked email
+- `POST /api/password/reset/start` - Start OPAQUE reset registration with reset token
+- `POST /api/password/reset/finish` - Finish reset, consume token, replace password record, and revoke sessions
+
 ### OTP (TOTP) — User
 - `POST /api/otp/setup/init`
 - `POST /api/otp/setup/verify`
@@ -305,6 +313,12 @@ When OTP is enabled and required by the user organization policy (`organizations
 5. JWE delivered via URL fragment (never hits server)
 6. App verifies hash binding and decrypts DRK
 
+### Email Password Reset and Encrypted Data
+
+Email reset restores account access by creating a new OPAQUE password record. It does not decrypt
+DRK-wrapped data that depends on the old password-derived export key. After reset, users may need to
+use the existing old-password recovery flow or generate new keys.
+
 ## Building for Production
 
 ```bash
@@ -355,6 +369,7 @@ npm run test:debug
 6. **Rate limiting** - Configurable per endpoint
 7. **Session security** - Short-lived sessions with CSRF protection
 8. **OTP hardening** - Secrets encrypted with KEK, backup codes hashed with Argon2, anti-replay via timestep tracking, cohort/organization enforcement, AMR/ACR reflect MFA
+9. **Password reset** - Enable only with working SMTP; reset requests use generic responses, HMAC-hashed one-time tokens, rate limits, audit events, and post-reset session revocation
 
 ## Support
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ This directory contains concise implementation-aligned documentation for DarkAut
 
 - [Organization RBAC](./organization-rbac.md): org memberships, role/permission derivation, org context resolution (`ORG_CONTEXT_REQUIRED`), user org endpoints, admin org/member/role endpoints (including member role add/remove compatibility routes), token org claims, and global-group UI status.
 - [Admin Table and List Standards](./admin-list-standards.md): shared admin table UX, list query contract, pagination shape, and list bounds.
+- [Email Password Reset](./password-reset.md): SMTP-gated self-service reset flow, token storage, API endpoints, template variables, session invalidation, and zero-knowledge recovery boundaries.
 
 ## Development Guides
 

--- a/docs/password-reset.md
+++ b/docs/password-reset.md
@@ -1,0 +1,111 @@
+# Email Password Reset
+
+DarkAuth supports self-service password reset for user accounts when outbound email is configured.
+The flow restores account access only; it does not decrypt user data that was wrapped under the
+previous OPAQUE export key.
+
+## Admin Setup
+
+1. Configure SMTP in Admin Settings under `Email / SMTP`.
+2. Enable `email.smtp.enabled`.
+3. Enable `users.password_reset_email_enabled` under `Users / Password Reset`.
+4. Keep `users.password_reset_show_login_link` enabled to show the login-page link.
+5. Review `email.templates.password_recovery` under Admin Email Templates.
+
+Password reset cannot be enabled until SMTP sending is available. The setting remains disabled by
+default for existing and new installs.
+
+## Settings
+
+- `users.password_reset_email_enabled`: enables email reset requests when SMTP is available.
+- `users.password_reset_show_login_link`: controls the `Forgot your password?` login-page link.
+- `users.password_reset_token_ttl_minutes`: reset link lifetime, from 5 to 1440 minutes.
+- `users.password_reset_request_cooldown_minutes`: per-account cooldown, from 1 to 60 minutes.
+- `users.password_reset_max_requests_per_hour`: per-account hourly cap, from 1 to 20 requests.
+
+The public `/config.js` exposes only whether the link should be visible. It does not expose SMTP
+state or detailed reset configuration.
+
+## User Flow
+
+1. User opens `/forgot-password`.
+2. User submits an email address.
+3. DarkAuth always returns `If an account exists, we sent reset instructions.`
+4. If the account exists, the feature is enabled, SMTP works, and email policy allows it, DarkAuth
+   creates a single-use reset token and sends `email.templates.password_recovery`.
+5. User opens `/reset-password?token=...`.
+6. The UI validates the token, runs OPAQUE reset registration start/finish, and returns the user to
+   login after success.
+
+The reset flow never logs the user in automatically. Existing OTP requirements still apply on the
+next login.
+
+## Admin-Triggered Reset Email
+
+Write admins can send a reset email from a user detail page or call:
+
+- `POST /admin/users/{userSub}/password/reset-email`
+
+This uses the same reset-token creation and `password_recovery` template as the public request flow.
+The admin never sees the plaintext reset token. The action requires password reset and SMTP sending
+to be enabled and writes `ADMIN_USER_PASSWORD_RESET_EMAIL_SENT` audit events.
+
+## API Endpoints
+
+User API endpoints live under `/api/user` internally and are served from the user origin:
+
+- `POST /api/user/password/reset/request`
+- `GET /api/user/password/reset/token?token=...`
+- `POST /api/user/password/reset/start`
+- `POST /api/user/password/reset/finish`
+
+Request responses are designed to avoid account enumeration. Invalid, unknown, disabled, unverified,
+and SMTP-failure request paths return the same generic response.
+
+## Token Storage and Invalidation
+
+Reset tokens are generated with high entropy and only stored as HMAC-SHA-256 hashes using the
+server-side KEK passphrase when available. Creating a new token consumes any other active token for
+that user.
+
+Successful reset happens in one transaction:
+
+- Consume the reset token.
+- Replace the OPAQUE record.
+- Store password history hash for reuse checks.
+- Clear `users.password_reset_required`.
+- Consume other active reset tokens for the user.
+- Delete active user sessions, authorization codes, and pending authorization requests.
+
+## Email Template
+
+The reset email uses `email.templates.password_recovery`.
+
+Supported variables:
+
+- `name`
+- `email`
+- `reset_link`
+- `recovery_link`
+- `expires_minutes`
+- `requested_at`
+- `ip_hint`
+
+`recovery_link` is kept as an alias for `reset_link` so existing customized templates continue to
+work.
+
+## Zero-Knowledge Recovery Boundary
+
+Email password reset creates a new OPAQUE password record and a new password-derived export key. It
+does not recover old encrypted material by itself.
+
+If an app depends on wrapped DRK or wrapped private-key material, users may need to complete the
+existing old-password recovery flow after signing in with the new password. If the old password is
+not available, the user can generate new keys, but old encrypted content may remain unavailable
+unless another recovery path exists.
+
+## Audit and Security
+
+DarkAuth writes audit events for reset email sends, skipped sends, SMTP failures, invalid-token
+attempts, completed resets, and rate-limited requests. Plaintext reset tokens are never logged or
+shown to admins.

--- a/packages/admin-ui/src/pages/EmailTemplates.tsx
+++ b/packages/admin-ui/src/pages/EmailTemplates.tsx
@@ -44,9 +44,17 @@ const TEMPLATE_DEFINITIONS: TemplateDefinition[] = [
   },
   {
     key: "password_recovery",
-    label: "Password recovery",
-    description: "Sent when a user requests account recovery.",
-    variables: ["name", "recovery_link"],
+    label: "Password reset",
+    description: "Sent when a user requests a password reset.",
+    variables: [
+      "name",
+      "email",
+      "reset_link",
+      "recovery_link",
+      "expires_minutes",
+      "requested_at",
+      "ip_hint",
+    ],
   },
   {
     key: "admin_test_email",

--- a/packages/admin-ui/src/pages/Settings.tsx
+++ b/packages/admin-ui/src/pages/Settings.tsx
@@ -18,6 +18,98 @@ import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
 import adminApiService, { type AdminSetting } from "@/services/api";
 
+const PASSWORD_RESET_SETTINGS: AdminSetting[] = [
+  {
+    key: "users.password_reset_email_enabled",
+    name: "Enable email password reset",
+    type: "boolean",
+    category: "Users / Password Reset",
+    description: "Allow users to request password reset emails when SMTP sending is available.",
+    tags: ["users", "password-reset"],
+    defaultValue: false,
+    value: false,
+    secure: false,
+    updatedAt: "",
+  },
+  {
+    key: "users.password_reset_show_login_link",
+    name: "Show forgot-password link",
+    type: "boolean",
+    category: "Users / Password Reset",
+    description:
+      "Show the forgot-password link on the user sign-in page when password reset is enabled.",
+    tags: ["users", "password-reset"],
+    defaultValue: true,
+    value: true,
+    secure: false,
+    updatedAt: "",
+  },
+  {
+    key: "users.password_reset_token_ttl_minutes",
+    name: "Token TTL minutes",
+    type: "number",
+    category: "Users / Password Reset",
+    description: "How long password reset links remain valid, from 5 to 1440 minutes.",
+    tags: ["users", "password-reset"],
+    defaultValue: 30,
+    value: 30,
+    secure: false,
+    updatedAt: "",
+  },
+  {
+    key: "users.password_reset_request_cooldown_minutes",
+    name: "Request cooldown minutes",
+    type: "number",
+    category: "Users / Password Reset",
+    description: "Minimum time between reset emails for the same account, from 1 to 60 minutes.",
+    tags: ["users", "password-reset"],
+    defaultValue: 5,
+    value: 5,
+    secure: false,
+    updatedAt: "",
+  },
+  {
+    key: "users.password_reset_max_requests_per_hour",
+    name: "Max requests per hour",
+    type: "number",
+    category: "Users / Password Reset",
+    description: "Maximum reset email requests per account each hour, from 1 to 20.",
+    tags: ["users", "password-reset"],
+    defaultValue: 3,
+    value: 3,
+    secure: false,
+    updatedAt: "",
+  },
+];
+
+const NUMBER_LIMITS: Record<string, { min: number; max: number }> = {
+  "users.password_reset_token_ttl_minutes": { min: 5, max: 1440 },
+  "users.password_reset_request_cooldown_minutes": { min: 1, max: 60 },
+  "users.password_reset_max_requests_per_hour": { min: 1, max: 20 },
+};
+
+function withPasswordResetSettings(settings: AdminSetting[]): AdminSetting[] {
+  const byKey = new Map(settings.map((setting) => [setting.key, setting]));
+  return [
+    ...settings.map((setting) => {
+      const fallback = PASSWORD_RESET_SETTINGS.find((item) => item.key === setting.key);
+      return fallback
+        ? {
+            ...fallback,
+            ...setting,
+            name: setting.name || fallback.name,
+            type: setting.type || fallback.type,
+            category: setting.category || fallback.category,
+            description: setting.description || fallback.description,
+            tags: setting.tags || fallback.tags,
+            defaultValue: setting.defaultValue ?? fallback.defaultValue,
+          }
+        : setting;
+    }),
+    ...PASSWORD_RESET_SETTINGS.filter((setting) => !byKey.has(setting.key)),
+  ];
+}
+
 function toLabel(key: string, name?: string | null) {
   if (name?.trim()) return name;
   return key.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase());
@@ -59,7 +151,7 @@ export default function Settings() {
         adminApiService.getSettings(),
         adminApiService.getAdminSession(),
       ]);
-      const settings = settingsResponse.settings;
+      const settings = withPasswordResetSettings(settingsResponse.settings);
       setAdminRole(sessionResponse.role || "read");
       setSettings(settings);
       const d: Record<string, unknown> = {};
@@ -136,7 +228,7 @@ export default function Settings() {
     }
   };
 
-  const smtpMissing = useMemo(() => {
+  const smtpUnavailable = useMemo(() => {
     const readString = (key: string) => {
       const v = drafts[key];
       return typeof v === "string" ? v.trim() : "";
@@ -153,8 +245,9 @@ export default function Settings() {
       port,
     };
     return (
+      drafts["email.smtp.enabled"] !== true ||
       !values.from ||
-      !values.transport ||
+      values.transport !== "smtp" ||
       !values.host ||
       !values.user ||
       !values.password ||
@@ -209,7 +302,7 @@ export default function Settings() {
                       right={
                         <Button
                           onClick={sendTestEmail}
-                          disabled={adminRole === "read" || smtpMissing}
+                          disabled={adminRole === "read" || smtpUnavailable}
                         >
                           Send test email
                         </Button>
@@ -220,6 +313,13 @@ export default function Settings() {
                 {inner.map(([sub, items]) => (
                   <div key={sub}>
                     {sub !== "General" && <div className={settingsStyles.subHeading}>{sub}</div>}
+                    {items.some((item) => item.key.startsWith("users.password_reset_")) ? (
+                      <SettingRow
+                        label="Password reset by email"
+                        description="Reset emails restore account access only. Encrypted data still requires old-password recovery or key regeneration after sign-in."
+                        right={null}
+                      />
+                    ) : null}
                     <div className={settingsStyles.rows}>
                       {items
                         .slice()
@@ -229,8 +329,15 @@ export default function Settings() {
                         .map((s) => {
                           const t = inferType(s);
                           const label = toLabel(s.key, s.name);
+                          const enablePasswordResetBlocked =
+                            s.key === "users.password_reset_email_enabled" &&
+                            smtpUnavailable &&
+                            !drafts[s.key];
                           const disabled =
-                            savingKey === s.key || (s.secure && s.value === "[REDACTED]");
+                            adminRole === "read" ||
+                            savingKey === s.key ||
+                            (s.secure && s.value === "[REDACTED]") ||
+                            enablePasswordResetBlocked;
                           const isObject = t === "object";
                           const atDefault = isObject
                             ? JSON.stringify(s.value) === JSON.stringify(s.defaultValue)
@@ -239,7 +346,11 @@ export default function Settings() {
                             <SettingRow
                               key={s.key}
                               label={label}
-                              description={s.description || undefined}
+                              description={
+                                enablePasswordResetBlocked
+                                  ? "Complete and enable SMTP settings before enabling email password reset."
+                                  : s.description || undefined
+                              }
                               className={savingKey === s.key ? settingsStyles.saving : undefined}
                               right={
                                 t === "boolean" ? (
@@ -250,20 +361,23 @@ export default function Settings() {
                                       adminApiService
                                         .updateSetting(s.key, !!v)
                                         .then(() => toast({ title: "Saved", description: s.key }))
-                                        .catch((e) =>
+                                        .catch((e) => {
+                                          setDrafts((d) => ({ ...d, [s.key]: s.value }));
                                           toast({
                                             title: "Error",
                                             description:
                                               e instanceof Error ? e.message : "Failed to save",
                                             variant: "destructive",
-                                          })
-                                        );
+                                          });
+                                        });
                                     }}
                                     disabled={disabled}
                                   />
                                 ) : t === "number" ? (
                                   <Input
                                     type="number"
+                                    min={NUMBER_LIMITS[s.key]?.min}
+                                    max={NUMBER_LIMITS[s.key]?.max}
                                     value={String(drafts[s.key] ?? "")}
                                     onChange={(e) =>
                                       setDrafts((d) => ({ ...d, [s.key]: e.target.value }))

--- a/packages/admin-ui/src/pages/UserEdit.tsx
+++ b/packages/admin-ui/src/pages/UserEdit.tsx
@@ -26,6 +26,8 @@ export default function UserEdit() {
     created_at?: string | null;
     last_used_at?: string | null;
   } | null>(null);
+  const [resetEmailSending, setResetEmailSending] = useState(false);
+  const [resetEmailMessage, setResetEmailMessage] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -70,6 +72,21 @@ export default function UserEdit() {
     }
   };
 
+  const sendPasswordResetEmail = async () => {
+    if (!user) return;
+    try {
+      setResetEmailSending(true);
+      setError(null);
+      setResetEmailMessage(null);
+      await adminApiService.sendUserPasswordResetEmail(user.sub);
+      setResetEmailMessage("Password reset email sent");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to send password reset email");
+    } finally {
+      setResetEmailSending(false);
+    }
+  };
+
   if (loading) return <div>Loading user...</div>;
 
   if (error)
@@ -110,6 +127,11 @@ export default function UserEdit() {
               </AlertDescription>
             </Alert>
           )}
+          {resetEmailMessage && (
+            <Alert style={{ marginBottom: 16 }}>
+              <AlertTitle>{resetEmailMessage}</AlertTitle>
+            </Alert>
+          )}
           <FormGrid columns={2}>
             <FormField label={<Label>Subject ID</Label>}>
               <Input value={user.sub} readOnly />
@@ -131,6 +153,13 @@ export default function UserEdit() {
           <FormActions withMargin>
             {user && (
               <>
+                <Button
+                  variant="outline"
+                  disabled={resetEmailSending}
+                  onClick={sendPasswordResetEmail}
+                >
+                  {resetEmailSending ? "Sending..." : "Send Reset Email"}
+                </Button>
                 <Button
                   variant="outline"
                   onClick={async () => {

--- a/packages/admin-ui/src/services/api.ts
+++ b/packages/admin-ui/src/services/api.ts
@@ -520,6 +520,10 @@ class AdminApiService {
     return this.request(`/users/${userSub}/password/reset`, { method: "POST" });
   }
 
+  async sendUserPasswordResetEmail(userSub: string): Promise<{ success: boolean }> {
+    return this.request(`/users/${userSub}/password/reset-email`, { method: "POST" });
+  }
+
   async requireAdminPasswordReset(adminId: string): Promise<{ success: boolean }> {
     return this.request(`/admin-users/${adminId}/password/reset`, { method: "POST" });
   }

--- a/packages/api/drizzle/0021_password_reset_email.sql
+++ b/packages/api/drizzle/0021_password_reset_email.sql
@@ -1,0 +1,38 @@
+CREATE TABLE IF NOT EXISTS "password_reset_tokens" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_sub" text NOT NULL,
+  "email" text NOT NULL,
+  "token_hash" text NOT NULL,
+  "expires_at" timestamp NOT NULL,
+  "consumed_at" timestamp,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "requested_ip_hash" text,
+  "user_agent_hash" text,
+  CONSTRAINT "password_reset_tokens_token_hash_unique" UNIQUE("token_hash"),
+  CONSTRAINT "password_reset_tokens_user_sub_users_sub_fk" FOREIGN KEY ("user_sub") REFERENCES "users"("sub") ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "password_reset_tokens_user_sub_idx" ON "password_reset_tokens" USING btree ("user_sub");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "password_reset_tokens_email_idx" ON "password_reset_tokens" USING btree ("email");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "password_reset_tokens_expires_at_idx" ON "password_reset_tokens" USING btree ("expires_at");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "password_reset_tokens_active_user_idx" ON "password_reset_tokens" USING btree ("user_sub","consumed_at");
+--> statement-breakpoint
+INSERT INTO "settings" ("key", "name", "type", "category", "description", "tags", "default_value", "value", "secure", "updated_at") VALUES
+('users.password_reset_email_enabled', 'Email Password Reset Enabled', 'boolean', 'Users / Password Reset', 'Allow users to request password reset links by email', ARRAY['users', 'email', 'password-reset']::text[], 'false'::jsonb, 'false'::jsonb, false, now()),
+('users.password_reset_show_login_link', 'Show Forgot Password Link', 'boolean', 'Users / Password Reset', 'Show the forgot password link on the user login page', ARRAY['users', 'email', 'password-reset']::text[], 'true'::jsonb, 'true'::jsonb, false, now()),
+('users.password_reset_token_ttl_minutes', 'Password Reset Token TTL (minutes)', 'number', 'Users / Password Reset', 'Minutes until password reset links expire', ARRAY['users', 'email', 'password-reset']::text[], '30'::jsonb, '30'::jsonb, false, now()),
+('users.password_reset_request_cooldown_minutes', 'Password Reset Cooldown (minutes)', 'number', 'Users / Password Reset', 'Minimum minutes between reset emails for one account', ARRAY['users', 'email', 'password-reset']::text[], '5'::jsonb, '5'::jsonb, false, now()),
+('users.password_reset_max_requests_per_hour', 'Password Reset Max Requests Per Hour', 'number', 'Users / Password Reset', 'Maximum reset emails per account per hour', ARRAY['users', 'email', 'password-reset']::text[], '3'::jsonb, '3'::jsonb, false, now()),
+('email.templates.password_recovery', 'password_recovery Template', 'object', 'Email / Templates', 'Template for password_recovery', ARRAY['email', 'templates']::text[], '{"subject":"Reset your password","text":"Hello {{name}},\n\nUse this link to reset your password:\n{{reset_link}}\n\nThis link expires in {{expires_minutes}} minutes.","html":"<p>Hello {{name}},</p><p>Use this link to reset your password:</p><p><a href=\"{{reset_link}}\">Reset password</a></p><p>This link expires in {{expires_minutes}} minutes.</p>"}'::jsonb, '{"subject":"Reset your password","text":"Hello {{name}},\n\nUse this link to reset your password:\n{{reset_link}}\n\nThis link expires in {{expires_minutes}} minutes.","html":"<p>Hello {{name}},</p><p>Use this link to reset your password:</p><p><a href=\"{{reset_link}}\">Reset password</a></p><p>This link expires in {{expires_minutes}} minutes.</p>"}'::jsonb, false, now())
+ON CONFLICT ("key") DO UPDATE SET
+"name" = excluded."name",
+"type" = excluded."type",
+"category" = excluded."category",
+"description" = excluded."description",
+"tags" = excluded."tags",
+"default_value" = excluded."default_value",
+"secure" = excluded."secure",
+"updated_at" = now();

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1773586800000,
       "tag": "0020_oauth_granted_scope",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1773673200000,
+      "tag": "0021_password_reset_email",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/controllers/admin/settingsUpdate.ts
+++ b/packages/api/src/controllers/admin/settingsUpdate.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { z } from "zod/v4";
 import { ForbiddenError, ValidationError } from "../../errors.ts";
 import { genericErrors } from "../../http/openapi-helpers.ts";
+import { isEmailSendingAvailable } from "../../services/email.ts";
 import { requireSession } from "../../services/sessions.ts";
 import { getSetting, setSetting } from "../../services/settings.ts";
 import type { Context, ControllerSchema } from "../../types.ts";
@@ -75,6 +76,14 @@ async function updateSettingsHandler(
     validateSmtpPort(data.value);
   } else if (data.key === "email.verification.token_ttl_minutes") {
     validateVerificationTtl(data.value);
+  } else if (data.key === "users.password_reset_token_ttl_minutes") {
+    validatePasswordResetTtl(data.value);
+  } else if (data.key === "users.password_reset_request_cooldown_minutes") {
+    validatePasswordResetCooldown(data.value);
+  } else if (data.key === "users.password_reset_max_requests_per_hour") {
+    validatePasswordResetHourlyMax(data.value);
+  } else if (data.key === "users.password_reset_email_enabled") {
+    await validatePasswordResetEnable(context, data.value);
   } else if (data.key === "email.smtp.enabled") {
     await validateSmtpEnable(context, data.value);
   }
@@ -113,6 +122,36 @@ function validateSmtpPort(value: unknown): void {
 function validateVerificationTtl(value: unknown): void {
   if (typeof value !== "number" || !Number.isInteger(value) || value < 5 || value > 10080) {
     throw new ValidationError("Verification token TTL must be between 5 and 10080 minutes");
+  }
+}
+
+function validatePasswordResetTtl(value: unknown): void {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 5 || value > 1440) {
+    throw new ValidationError("Password reset token TTL must be between 5 and 1440 minutes");
+  }
+}
+
+function validatePasswordResetCooldown(value: unknown): void {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1 || value > 60) {
+    throw new ValidationError("Password reset cooldown must be between 1 and 60 minutes");
+  }
+}
+
+function validatePasswordResetHourlyMax(value: unknown): void {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1 || value > 20) {
+    throw new ValidationError("Password reset max requests per hour must be between 1 and 20");
+  }
+}
+
+async function validatePasswordResetEnable(context: Context, value: unknown): Promise<void> {
+  if (typeof value !== "boolean") {
+    throw new ValidationError("Password reset enabled must be a boolean");
+  }
+  if (!value) return;
+  if (!(await isEmailSendingAvailable(context))) {
+    throw new ValidationError(
+      "Password reset cannot be enabled until SMTP is configured and enabled"
+    );
   }
 }
 
@@ -162,7 +201,20 @@ function validateRateLimitsSettings(value: unknown): void {
     throw new ValidationError("Rate limits must be an object");
   }
 
-  const validTypes = ["general", "auth", "opaque", "token", "admin", "install"];
+  const validTypes = [
+    "general",
+    "auth",
+    "opaque",
+    "token",
+    "admin",
+    "install",
+    "otp",
+    "otp_setup",
+    "otp_verify",
+    "otp_disable",
+    "otp_regenerate",
+    "password_reset",
+  ];
 
   for (const [type, config] of Object.entries(value as Record<string, unknown>)) {
     if (!validTypes.includes(type)) {

--- a/packages/api/src/controllers/admin/userPasswordResetEmail.ts
+++ b/packages/api/src/controllers/admin/userPasswordResetEmail.ts
@@ -1,0 +1,56 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { z } from "zod/v4";
+import { ForbiddenError } from "../../errors.ts";
+import { genericErrors } from "../../http/openapi-helpers.ts";
+import { sendAdminPasswordResetEmail } from "../../services/passwordReset.ts";
+import { requireSession } from "../../services/sessions.ts";
+import type { Context, ControllerSchema } from "../../types.ts";
+import { getClientIp, sendJson } from "../../utils/http.ts";
+
+const SuccessResponseSchema = z.object({
+  success: z.boolean(),
+});
+
+export async function postUserPasswordResetEmail(
+  context: Context,
+  request: IncomingMessage,
+  response: ServerResponse,
+  ...params: string[]
+): Promise<void> {
+  const Params = z.object({ userSub: z.string() });
+  const { userSub } = Params.parse({ userSub: params[0] });
+  const session = await requireSession(context, request, true);
+  if (session.adminRole !== "write" || !session.adminId) {
+    throw new ForbiddenError("Write permission required");
+  }
+
+  const result = await sendAdminPasswordResetEmail(context, {
+    userSub,
+    adminId: session.adminId,
+    ipAddress: getClientIp(request),
+    userAgent:
+      typeof request.headers["user-agent"] === "string" ? request.headers["user-agent"] : undefined,
+  });
+  sendJson(response, 200, result);
+}
+
+export const schema = {
+  method: "POST",
+  path: "/admin/users/{userSub}/password/reset-email",
+  tags: ["Users"],
+  summary: "Send user password reset email",
+  params: z.object({
+    userSub: z.string(),
+  }),
+  responses: {
+    200: {
+      description: "Password reset email sent",
+      content: {
+        "application/json": {
+          schema: SuccessResponseSchema,
+        },
+      },
+    },
+    ...genericErrors,
+  },
+} as const satisfies ControllerSchema;

--- a/packages/api/src/controllers/user/passwordResetFinish.ts
+++ b/packages/api/src/controllers/user/passwordResetFinish.ts
@@ -1,0 +1,56 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { z } from "zod/v4";
+import { ValidationError } from "../../errors.ts";
+import { genericErrors } from "../../http/openapi-helpers.ts";
+import { getCachedBody, withRateLimit } from "../../middleware/rateLimit.ts";
+import { finishPasswordResetRegistration } from "../../services/passwordReset.ts";
+import type { Context, ControllerSchema } from "../../types.ts";
+import { fromBase64Url } from "../../utils/crypto.ts";
+import { getClientIp, parseJsonSafely, sendJson } from "../../utils/http.ts";
+
+const PasswordResetFinishBody = z.object({
+  token: z.string().min(1),
+  record: z.string(),
+  export_key_hash: z.string(),
+});
+
+async function postPasswordResetFinishHandler(
+  context: Context,
+  request: IncomingMessage,
+  response: ServerResponse
+): Promise<void> {
+  const body = await getCachedBody(request);
+  const raw = parseJsonSafely(body);
+  const parsed = PasswordResetFinishBody.parse(raw);
+  let recordBuffer: Uint8Array;
+  try {
+    recordBuffer = fromBase64Url(parsed.record);
+  } catch {
+    throw new ValidationError("Invalid base64url encoding in record");
+  }
+  const result = await finishPasswordResetRegistration(context, {
+    token: parsed.token,
+    recordBuffer,
+    exportKeyHash: parsed.export_key_hash,
+    ipAddress: getClientIp(request),
+    userAgent:
+      typeof request.headers["user-agent"] === "string" ? request.headers["user-agent"] : undefined,
+  });
+  sendJson(response, 200, result);
+}
+
+export const postPasswordResetFinish = withRateLimit("opaque")(postPasswordResetFinishHandler);
+
+export const schema = {
+  method: "POST",
+  path: "/password/reset/finish",
+  tags: ["OPAQUE"],
+  summary: "passwordResetFinish",
+  body: {
+    description: "Request body",
+    required: true,
+    contentType: "application/json",
+    schema: PasswordResetFinishBody,
+  },
+  responses: { 200: { description: "OK" }, ...genericErrors },
+} as const satisfies ControllerSchema;

--- a/packages/api/src/controllers/user/passwordResetRequest.ts
+++ b/packages/api/src/controllers/user/passwordResetRequest.ts
@@ -1,0 +1,59 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { z } from "zod/v4";
+import { genericErrors } from "../../http/openapi-helpers.ts";
+import { getCachedBody, withRateLimit } from "../../middleware/rateLimit.ts";
+import {
+  normalizePasswordResetEmail,
+  requestPasswordResetEmail,
+} from "../../services/passwordReset.ts";
+import type { Context, ControllerSchema } from "../../types.ts";
+import { getClientIp, parseJsonSafely, sendJson } from "../../utils/http.ts";
+
+const PasswordResetRequestBody = z.object({
+  email: z.string().email(),
+});
+
+async function postPasswordResetRequestHandler(
+  context: Context,
+  request: IncomingMessage,
+  response: ServerResponse
+): Promise<void> {
+  const body = await getCachedBody(request);
+  const raw = parseJsonSafely(body);
+  const parsed = PasswordResetRequestBody.safeParse(raw);
+  if (!parsed.success) {
+    sendJson(response, 200, {
+      success: true,
+      message: "If an account exists, we sent reset instructions.",
+    });
+    return;
+  }
+
+  const result = await requestPasswordResetEmail(context, {
+    email: parsed.data.email,
+    ipAddress: getClientIp(request),
+    userAgent:
+      typeof request.headers["user-agent"] === "string" ? request.headers["user-agent"] : undefined,
+  });
+  sendJson(response, 200, result);
+}
+
+export const postPasswordResetRequest = withRateLimit("password_reset", (body) =>
+  body && typeof body === "object" && "email" in body
+    ? normalizePasswordResetEmail(String((body as { email?: unknown }).email || ""))
+    : undefined
+)(postPasswordResetRequestHandler);
+
+export const schema = {
+  method: "POST",
+  path: "/password/reset/request",
+  tags: ["OPAQUE"],
+  summary: "passwordResetRequest",
+  body: {
+    description: "Request body",
+    required: true,
+    contentType: "application/json",
+    schema: PasswordResetRequestBody,
+  },
+  responses: { 200: { description: "OK" }, ...genericErrors },
+} as const satisfies ControllerSchema;

--- a/packages/api/src/controllers/user/passwordResetStart.ts
+++ b/packages/api/src/controllers/user/passwordResetStart.ts
@@ -1,0 +1,54 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { z } from "zod/v4";
+import { ValidationError } from "../../errors.ts";
+import { genericErrors } from "../../http/openapi-helpers.ts";
+import { getCachedBody, withRateLimit } from "../../middleware/rateLimit.ts";
+import { startPasswordResetRegistration } from "../../services/passwordReset.ts";
+import type { Context, ControllerSchema } from "../../types.ts";
+import { fromBase64Url } from "../../utils/crypto.ts";
+import { getClientIp, parseJsonSafely, sendJson } from "../../utils/http.ts";
+
+const PasswordResetStartBody = z.object({
+  token: z.string().min(1),
+  request: z.string(),
+});
+
+async function postPasswordResetStartHandler(
+  context: Context,
+  request: IncomingMessage,
+  response: ServerResponse
+): Promise<void> {
+  const body = await getCachedBody(request);
+  const raw = parseJsonSafely(body);
+  const parsed = PasswordResetStartBody.parse(raw);
+  let requestBuffer: Uint8Array;
+  try {
+    requestBuffer = fromBase64Url(parsed.request);
+  } catch {
+    throw new ValidationError("Invalid base64url encoding in request");
+  }
+  const result = await startPasswordResetRegistration(context, {
+    token: parsed.token,
+    requestBuffer,
+    ipAddress: getClientIp(request),
+    userAgent:
+      typeof request.headers["user-agent"] === "string" ? request.headers["user-agent"] : undefined,
+  });
+  sendJson(response, 200, result);
+}
+
+export const postPasswordResetStart = withRateLimit("opaque")(postPasswordResetStartHandler);
+
+export const schema = {
+  method: "POST",
+  path: "/password/reset/start",
+  tags: ["OPAQUE"],
+  summary: "passwordResetStart",
+  body: {
+    description: "Request body",
+    required: true,
+    contentType: "application/json",
+    schema: PasswordResetStartBody,
+  },
+  responses: { 200: { description: "OK" }, ...genericErrors },
+} as const satisfies ControllerSchema;

--- a/packages/api/src/controllers/user/passwordResetToken.ts
+++ b/packages/api/src/controllers/user/passwordResetToken.ts
@@ -1,0 +1,37 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { z } from "zod/v4";
+import { genericErrors } from "../../http/openapi-helpers.ts";
+import { withRateLimit } from "../../middleware/rateLimit.ts";
+import { validatePasswordResetTokenForDisplay } from "../../services/passwordReset.ts";
+import type { Context, ControllerSchema } from "../../types.ts";
+import { parseQueryParams, sendJson } from "../../utils/http.ts";
+
+const PasswordResetTokenQuery = z.object({
+  token: z.string().min(1),
+});
+
+async function getPasswordResetTokenHandler(
+  context: Context,
+  request: IncomingMessage,
+  response: ServerResponse
+): Promise<void> {
+  const query = Object.fromEntries(parseQueryParams(request.url || ""));
+  const parsed = PasswordResetTokenQuery.safeParse(query);
+  if (!parsed.success) {
+    sendJson(response, 200, { valid: false });
+    return;
+  }
+  const result = await validatePasswordResetTokenForDisplay(context, parsed.data.token);
+  sendJson(response, 200, result);
+}
+
+export const getPasswordResetToken = withRateLimit("password_reset")(getPasswordResetTokenHandler);
+
+export const schema = {
+  method: "GET",
+  path: "/password/reset/token",
+  tags: ["OPAQUE"],
+  summary: "passwordResetToken",
+  query: PasswordResetTokenQuery,
+  responses: { 200: { description: "OK" }, ...genericErrors },
+} as const satisfies ControllerSchema;

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -137,6 +137,32 @@ export const emailVerificationTokens = pgTable(
   })
 );
 
+export const passwordResetTokens = pgTable(
+  "password_reset_tokens",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userSub: text("user_sub")
+      .notNull()
+      .references(() => users.sub, { onDelete: "cascade" }),
+    email: text("email").notNull(),
+    tokenHash: text("token_hash").notNull().unique(),
+    expiresAt: timestamp("expires_at").notNull(),
+    consumedAt: timestamp("consumed_at"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    requestedIpHash: text("requested_ip_hash"),
+    userAgentHash: text("user_agent_hash"),
+  },
+  (table) => ({
+    userSubIdx: index("password_reset_tokens_user_sub_idx").on(table.userSub),
+    emailIdx: index("password_reset_tokens_email_idx").on(table.email),
+    expiresAtIdx: index("password_reset_tokens_expires_at_idx").on(table.expiresAt),
+    activeUserIdx: index("password_reset_tokens_active_user_idx").on(
+      table.userSub,
+      table.consumedAt
+    ),
+  })
+);
+
 export const opaqueRecords = pgTable("opaque_records", {
   sub: text("sub")
     .primaryKey()
@@ -445,11 +471,19 @@ export const usersRelations = relations(users, ({ one, many }) => ({
   organizations: many(organizationMembers),
   permissions: many(userPermissions),
   emailVerificationTokens: many(emailVerificationTokens),
+  passwordResetTokens: many(passwordResetTokens),
 }));
 
 export const emailVerificationTokensRelations = relations(emailVerificationTokens, ({ one }) => ({
   user: one(users, {
     fields: [emailVerificationTokens.userSub],
+    references: [users.sub],
+  }),
+}));
+
+export const passwordResetTokensRelations = relations(passwordResetTokens, ({ one }) => ({
+  user: one(users, {
+    fields: [passwordResetTokens.userSub],
     references: [users.sub],
   }),
 }));

--- a/packages/api/src/http/createServer.ts
+++ b/packages/api/src/http/createServer.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 import { clients } from "../db/schema.ts";
 import { sanitizeLoggedError } from "../services/audit.ts";
 import { getBrandingConfig, sanitizeCSS } from "../services/branding.ts";
+import { shouldShowPasswordResetLink } from "../services/passwordReset.ts";
 import { getSetting, isSystemInitialized } from "../services/settings.ts";
 import type { Context } from "../types.ts";
 import { sendError } from "../utils/http.ts";
@@ -148,12 +149,14 @@ export async function createUserServer(context: Context) {
           | boolean
           | null
           | undefined;
+        const passwordResetEnabled = await shouldShowPasswordResetLink(context);
         const payload = {
           issuer,
           clientId: ui.clientId || "user",
           redirectUri: ui.redirectUri || `${publicOrigin}/callback`,
           features: {
             selfRegistrationEnabled: !!selfReg,
+            passwordResetEnabled,
           },
           branding: {
             identity: branding?.identity || {

--- a/packages/api/src/http/openapi.ts
+++ b/packages/api/src/http/openapi.ts
@@ -63,6 +63,7 @@ import { schema as adminUserOtpSchema } from "../controllers/admin/userOtp.ts";
 import { schema as adminUserOtpDeleteSchema } from "../controllers/admin/userOtpDelete.ts";
 import { schema as adminUserOtpUnlockSchema } from "../controllers/admin/userOtpUnlock.ts";
 import { schema as adminUserPasswordResetSchema } from "../controllers/admin/userPasswordReset.ts";
+import { schema as adminUserPasswordResetEmailSchema } from "../controllers/admin/userPasswordResetEmail.ts";
 import { schema as adminUserPasswordSetFinishSchema } from "../controllers/admin/userPasswordSetFinish.ts";
 import { schema as adminUserPasswordSetStartSchema } from "../controllers/admin/userPasswordSetStart.ts";
 import { schema as adminUserPermissionsSchema } from "../controllers/admin/userPermissions.ts";
@@ -99,6 +100,10 @@ import { schema as userPasswordChangeFinishSchema } from "../controllers/user/pa
 import { schema as userPasswordChangeStartSchema } from "../controllers/user/passwordChangeStart.ts";
 import { schema as userPasswordChangeVerifyFinishSchema } from "../controllers/user/passwordChangeVerifyFinish.ts";
 import { schema as userPasswordChangeVerifyStartSchema } from "../controllers/user/passwordChangeVerifyStart.ts";
+import { schema as userPasswordResetFinishSchema } from "../controllers/user/passwordResetFinish.ts";
+import { schema as userPasswordResetRequestSchema } from "../controllers/user/passwordResetRequest.ts";
+import { schema as userPasswordResetStartSchema } from "../controllers/user/passwordResetStart.ts";
+import { schema as userPasswordResetTokenSchema } from "../controllers/user/passwordResetToken.ts";
 import { schema as userProfileEmailSchema } from "../controllers/user/profileEmailUpdate.ts";
 import { schema as userSessionSchema } from "../controllers/user/session.ts";
 import { schema as userTokenSchema } from "../controllers/user/token.ts";
@@ -179,6 +184,7 @@ const documentedSchemas: ControllerSchema[] = [
   adminUserPasswordSetStartSchema,
   adminUserPasswordSetFinishSchema,
   adminUserPasswordResetSchema,
+  adminUserPasswordResetEmailSchema,
   adminPasswordChangeFinishSchema,
   adminJwksSchema,
   adminJwksRotateSchema,
@@ -210,6 +216,10 @@ const documentedSchemas: ControllerSchema[] = [
   userPasswordChangeFinishSchema,
   userPasswordChangeVerifyStartSchema,
   userPasswordChangeVerifyFinishSchema,
+  userPasswordResetRequestSchema,
+  userPasswordResetTokenSchema,
+  userPasswordResetStartSchema,
+  userPasswordResetFinishSchema,
   userProfileEmailSchema,
   userEncPublicGetSchema,
   userEncPublicPutSchema,

--- a/packages/api/src/http/routers/adminRouter.ts
+++ b/packages/api/src/http/routers/adminRouter.ts
@@ -64,6 +64,7 @@ import { getUserOtp } from "../../controllers/admin/userOtp.ts";
 import { deleteUserOtp } from "../../controllers/admin/userOtpDelete.ts";
 import { postUserOtpUnlock } from "../../controllers/admin/userOtpUnlock.ts";
 import { postUserPasswordReset } from "../../controllers/admin/userPasswordReset.ts";
+import { postUserPasswordResetEmail } from "../../controllers/admin/userPasswordResetEmail.ts";
 import { postUserPasswordSetFinish } from "../../controllers/admin/userPasswordSetFinish.ts";
 import { postUserPasswordSetStart } from "../../controllers/admin/userPasswordSetStart.ts";
 import { getUserPermissions } from "../../controllers/admin/userPermissions.ts";
@@ -154,6 +155,15 @@ export function createAdminRouter(context: Context) {
         const userSub = userResetMatch[1];
         if (method === "POST")
           return await postUserPasswordReset(context, request, response, userSub as string);
+      }
+
+      const userResetEmailMatch = pathname.match(
+        /^\/admin\/users\/([^/]+)\/password\/reset-email$/
+      );
+      if (userResetEmailMatch) {
+        const userSub = userResetEmailMatch[1];
+        if (method === "POST")
+          return await postUserPasswordResetEmail(context, request, response, userSub as string);
       }
 
       const userSetStartMatch = pathname.match(/^\/admin\/users\/([^/]+)\/password\/set\/start$/);

--- a/packages/api/src/http/routers/userRouter.ts
+++ b/packages/api/src/http/routers/userRouter.ts
@@ -31,6 +31,10 @@ import { postUserPasswordVerifyFinish } from "../../controllers/user/passwordCha
 import { postUserPasswordVerifyStart } from "../../controllers/user/passwordChangeVerifyStart.ts";
 import { postUserPasswordRecoveryVerifyFinish } from "../../controllers/user/passwordRecoveryVerifyFinish.ts";
 import { postUserPasswordRecoveryVerifyStart } from "../../controllers/user/passwordRecoveryVerifyStart.ts";
+import { postPasswordResetFinish } from "../../controllers/user/passwordResetFinish.ts";
+import { postPasswordResetRequest } from "../../controllers/user/passwordResetRequest.ts";
+import { postPasswordResetStart } from "../../controllers/user/passwordResetStart.ts";
+import { getPasswordResetToken } from "../../controllers/user/passwordResetToken.ts";
 import { putUserProfileEmail } from "../../controllers/user/profileEmailUpdate.ts";
 import { getScopeDescriptions } from "../../controllers/user/scopeDescriptions.ts";
 import { getSession, postSessionOrganization } from "../../controllers/user/session.ts";
@@ -51,7 +55,7 @@ import { sanitizeAuditPath, sanitizeLoggedError } from "../../services/audit.ts"
 import { sanitizeCSS } from "../../services/branding.ts";
 import { getSetting } from "../../services/settings.ts";
 import type { Context } from "../../types.ts";
-import { assertCsrf } from "../../utils/csrf.ts";
+import { assertCsrf, assertSameOrigin } from "../../utils/csrf.ts";
 import { sendError } from "../../utils/http.ts";
 
 function readColor(
@@ -71,7 +75,18 @@ export function createUserRouter(context: Context) {
     const pathname = url.pathname;
 
     try {
-      const needsCsrf = !["GET", "HEAD", "OPTIONS"].includes(method) && pathname !== "/token";
+      const isPublicAuthPost =
+        method === "POST" &&
+        [
+          "/opaque/login/start",
+          "/opaque/login/finish",
+          "/password/reset/request",
+          "/password/reset/start",
+          "/password/reset/finish",
+        ].includes(pathname);
+      const needsCsrf =
+        !["GET", "HEAD", "OPTIONS"].includes(method) && pathname !== "/token" && !isPublicAuthPost;
+      if (isPublicAuthPost) assertSameOrigin(request);
       if (needsCsrf) assertCsrf(request, false);
       if (method === "GET" && pathname === "/branding/logo") {
         const url = new URL(request.url || "", `http://${request.headers.host}`);
@@ -326,6 +341,22 @@ export function createUserRouter(context: Context) {
 
       if (method === "POST" && pathname === "/password/recovery/verify/finish") {
         return await postUserPasswordRecoveryVerifyFinish(context, request, response);
+      }
+
+      if (method === "POST" && pathname === "/password/reset/request") {
+        return await postPasswordResetRequest(context, request, response);
+      }
+
+      if (method === "GET" && pathname === "/password/reset/token") {
+        return await getPasswordResetToken(context, request, response);
+      }
+
+      if (method === "POST" && pathname === "/password/reset/start") {
+        return await postPasswordResetStart(context, request, response);
+      }
+
+      if (method === "POST" && pathname === "/password/reset/finish") {
+        return await postPasswordResetFinish(context, request, response);
       }
 
       if (method === "POST" && pathname === "/opaque/login/start") {

--- a/packages/api/src/models/passwordResetTokens.test.ts
+++ b/packages/api/src/models/passwordResetTokens.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { eq } from "drizzle-orm";
+import { createPglite } from "../db/pglite.ts";
+import { passwordResetTokens, users } from "../db/schema.ts";
+import { ValidationError } from "../errors.ts";
+import type { Context } from "../types.ts";
+import {
+  createPasswordResetToken,
+  getActivePasswordResetToken,
+  invalidateActivePasswordResetTokens,
+  type PasswordResetTokenRow,
+} from "./passwordResetTokens.ts";
+
+function createLogger() {
+  return {
+    error() {},
+    warn() {},
+    info() {},
+    debug() {},
+    trace() {},
+    fatal() {},
+  };
+}
+
+async function ensurePasswordResetTokenTable(client: { query: (sql: string) => Promise<unknown> }) {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS password_reset_tokens (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_sub text NOT NULL REFERENCES users(sub) ON DELETE CASCADE,
+      email text NOT NULL,
+      token_hash text NOT NULL UNIQUE,
+      expires_at timestamp NOT NULL,
+      consumed_at timestamp,
+      created_at timestamp NOT NULL DEFAULT now(),
+      requested_ip_hash text,
+      user_agent_hash text
+    )
+  `);
+  await client.query(
+    "CREATE INDEX IF NOT EXISTS password_reset_tokens_user_sub_idx ON password_reset_tokens(user_sub)"
+  );
+  await client.query(
+    "CREATE INDEX IF NOT EXISTS password_reset_tokens_active_user_idx ON password_reset_tokens(user_sub, consumed_at)"
+  );
+}
+
+async function findActiveToken(
+  context: Context,
+  token: string
+): Promise<PasswordResetTokenRow | null> {
+  try {
+    return await getActivePasswordResetToken(context, token);
+  } catch (error) {
+    if (error instanceof ValidationError) return null;
+    throw error;
+  }
+}
+
+test("createPasswordResetToken stores only token hashes and invalidates older active tokens", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "darkauth-password-reset-token-test-"));
+  const { db, client, close } = await createPglite(directory);
+  const context = { db, logger: createLogger() } as Context;
+
+  try {
+    await ensurePasswordResetTokenTable(client);
+    await db.insert(users).values({ sub: "user-1", email: "user-1@example.com", name: "User One" });
+
+    const first = await createPasswordResetToken(context, {
+      userSub: "user-1",
+      email: "user-1@example.com",
+      ttlMinutes: 30,
+    });
+    const second = await createPasswordResetToken(context, {
+      userSub: "user-1",
+      email: "user-1@example.com",
+      ttlMinutes: 30,
+    });
+
+    assert.notEqual(first.token, second.token);
+    assert.match(first.token, /^[A-Za-z0-9_-]{43,}$/);
+    assert.match(second.token, /^[A-Za-z0-9_-]{43,}$/);
+
+    const rows = await db
+      .select()
+      .from(passwordResetTokens)
+      .where(eq(passwordResetTokens.userSub, "user-1"));
+    assert.equal(rows.length, 2);
+    assert.equal(rows.filter((row) => row.consumedAt === null).length, 1);
+    assert.ok(rows.every((row) => row.tokenHash !== first.token));
+    assert.ok(rows.every((row) => row.tokenHash !== second.token));
+
+    assert.equal(await findActiveToken(context, first.token), null);
+    const active = await findActiveToken(context, second.token);
+    assert.equal(active?.userSub, "user-1");
+    assert.equal(active?.email, "user-1@example.com");
+  } finally {
+    await close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("invalidateActivePasswordResetTokens and expiry prevent token validation", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "darkauth-password-reset-token-test-"));
+  const { db, client, close } = await createPglite(directory);
+  const context = { db, logger: createLogger() } as Context;
+
+  try {
+    await ensurePasswordResetTokenTable(client);
+    await db.insert(users).values({ sub: "user-1", email: "user-1@example.com", name: "User One" });
+    await db.insert(users).values({ sub: "user-2", email: "user-2@example.com", name: "User Two" });
+
+    const active = await createPasswordResetToken(context, {
+      userSub: "user-1",
+      email: "user-1@example.com",
+      ttlMinutes: 30,
+    });
+
+    assert.equal((await findActiveToken(context, active.token))?.userSub, "user-1");
+    await invalidateActivePasswordResetTokens(context, "user-1");
+    assert.equal(await findActiveToken(context, active.token), null);
+
+    const expired = await createPasswordResetToken(context, {
+      userSub: "user-2",
+      email: "user-2@example.com",
+      ttlMinutes: 30,
+    });
+    await db
+      .update(passwordResetTokens)
+      .set({ expiresAt: new Date(Date.now() - 1000) })
+      .where(eq(passwordResetTokens.userSub, "user-2"));
+
+    assert.equal(await findActiveToken(context, expired.token), null);
+  } finally {
+    await close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/packages/api/src/models/passwordResetTokens.ts
+++ b/packages/api/src/models/passwordResetTokens.ts
@@ -1,0 +1,103 @@
+import { createHmac } from "node:crypto";
+import { and, count, eq, gt, gte, isNull } from "drizzle-orm";
+import { passwordResetTokens } from "../db/schema.ts";
+import { ValidationError } from "../errors.ts";
+import type { Context } from "../types.ts";
+import { generateRandomString, sha256Base64Url } from "../utils/crypto.ts";
+
+export interface PasswordResetTokenRow {
+  id: string;
+  userSub: string;
+  email: string;
+  tokenHash: string;
+  expiresAt: Date;
+  consumedAt: Date | null;
+  createdAt: Date;
+}
+
+export function hashPasswordResetToken(context: Context, token: string): string {
+  const pepper = context.config?.kekPassphrase || context.config?.installToken || "DarkAuth";
+  return createHmac("sha256", pepper).update(token).digest("base64url");
+}
+
+export async function invalidateActivePasswordResetTokens(
+  context: Context,
+  userSub: string
+): Promise<void> {
+  await context.db
+    .update(passwordResetTokens)
+    .set({ consumedAt: new Date() })
+    .where(
+      and(
+        eq(passwordResetTokens.userSub, userSub),
+        isNull(passwordResetTokens.consumedAt),
+        gt(passwordResetTokens.expiresAt, new Date())
+      )
+    );
+}
+
+export async function createPasswordResetToken(
+  context: Context,
+  params: {
+    userSub: string;
+    email: string;
+    ttlMinutes: number;
+    requestedIp?: string;
+    userAgent?: string;
+  }
+): Promise<{ token: string; expiresAt: Date }> {
+  await invalidateActivePasswordResetTokens(context, params.userSub);
+  const token = generateRandomString(48);
+  const tokenHash = hashPasswordResetToken(context, token);
+  const expiresAt = new Date(Date.now() + Math.max(1, params.ttlMinutes) * 60 * 1000);
+  await context.db.insert(passwordResetTokens).values({
+    userSub: params.userSub,
+    email: params.email,
+    tokenHash,
+    expiresAt,
+    requestedIpHash: params.requestedIp ? sha256Base64Url(params.requestedIp) : null,
+    userAgentHash: params.userAgent ? sha256Base64Url(params.userAgent) : null,
+    createdAt: new Date(),
+  });
+  return { token, expiresAt };
+}
+
+export async function getActivePasswordResetToken(
+  context: Context,
+  token: string
+): Promise<PasswordResetTokenRow> {
+  const tokenHash = hashPasswordResetToken(context, token);
+  const row = await context.db.query.passwordResetTokens.findFirst({
+    where: eq(passwordResetTokens.tokenHash, tokenHash),
+  });
+  if (!row || row.consumedAt || row.expiresAt <= new Date()) {
+    throw new ValidationError("This password reset link is invalid or expired.");
+  }
+  return row;
+}
+
+export async function getLatestPasswordResetTokenForUser(
+  context: Context,
+  userSub: string
+): Promise<PasswordResetTokenRow | null> {
+  return (
+    (await context.db.query.passwordResetTokens.findFirst({
+      where: eq(passwordResetTokens.userSub, userSub),
+      orderBy: (table, { desc }) => [desc(table.createdAt)],
+    })) || null
+  );
+}
+
+export async function countPasswordResetTokensSince(
+  context: Context,
+  userSub: string,
+  since: Date
+): Promise<number> {
+  const [row] = await context.db
+    .select({ value: count() })
+    .from(passwordResetTokens)
+    .where(
+      and(eq(passwordResetTokens.userSub, userSub), gte(passwordResetTokens.createdAt, since))
+    );
+  return Number(row?.value || 0);
+}

--- a/packages/api/src/services/emailTemplates.test.ts
+++ b/packages/api/src/services/emailTemplates.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { Context } from "../types.ts";
+import { renderEmailTemplate } from "./emailTemplates.ts";
+
+function createContext(value: unknown): Context {
+  return {
+    db: {
+      query: {
+        settings: {
+          findFirst: async () => ({ value }),
+        },
+      },
+    },
+    services: {},
+  } as unknown as Context;
+}
+
+test("password_recovery template supports reset_link and recovery_link alias", async () => {
+  const context = createContext({
+    subject: "Reset for {{email}}",
+    text: "Open {{reset_link}} or {{recovery_link}} within {{expires_minutes}} minutes.",
+    html: '<a href="{{reset_link}}">Reset</a><a href="{{recovery_link}}">Recover</a>',
+  });
+
+  const rendered = await renderEmailTemplate(context, "password_recovery", {
+    email: "user@example.com",
+    reset_link: "https://auth.example.com/reset-password?token=reset",
+    recovery_link: "https://auth.example.com/reset-password?token=reset",
+    expires_minutes: "30",
+  });
+
+  assert.equal(rendered.subject, "Reset for user@example.com");
+  assert.match(rendered.text, /https:\/\/auth\.example\.com\/reset-password\?token=reset/);
+  assert.match(rendered.text, /30 minutes/);
+  assert.match(rendered.html, /Reset/);
+  assert.match(rendered.html, /Recover/);
+});

--- a/packages/api/src/services/emailTemplates.ts
+++ b/packages/api/src/services/emailTemplates.ts
@@ -37,9 +37,9 @@ const DEFAULT_TEMPLATES: Record<EmailTemplateKey, EmailTemplate> = {
     html: '<p>Hello {{name}},</p><p>Please verify your new email address by opening this link:</p><p><a href="{{verification_link}}">Verify new email</a></p><p>Your current email remains active until verification completes.</p>',
   },
   password_recovery: {
-    subject: "Password recovery",
-    text: "Hello {{name}},\n\nUse this link to recover access to your account:\n{{recovery_link}}",
-    html: '<p>Hello {{name}},</p><p>Use this link to recover access to your account:</p><p><a href="{{recovery_link}}">Recover account</a></p>',
+    subject: "Reset your password",
+    text: "Hello {{name}},\n\nUse this link to reset your password:\n{{reset_link}}\n\nThis link expires in {{expires_minutes}} minutes.",
+    html: '<p>Hello {{name}},</p><p>Use this link to reset your password:</p><p><a href="{{reset_link}}">Reset password</a></p><p>This link expires in {{expires_minutes}} minutes.</p>',
   },
   admin_test_email: {
     subject: "DarkAuth SMTP test",

--- a/packages/api/src/services/emailVerification.ts
+++ b/packages/api/src/services/emailVerification.ts
@@ -9,6 +9,7 @@ import {
 import type { Context } from "../types.ts";
 import { logAuditEvent } from "./audit.ts";
 import { isEmailSendingAvailable, sendTemplatedEmail } from "./email.ts";
+import { isPasswordResetEmailEnabled } from "./passwordReset.ts";
 import { getSetting } from "./settings.ts";
 
 function getVerificationLink(context: Context, token: string): string {
@@ -91,12 +92,15 @@ export async function sendSignupExistingAccountNotice(
   context: Context,
   params: { email: string; name: string }
 ): Promise<void> {
+  const recoveryLink = (await isPasswordResetEmailEnabled(context))
+    ? `${context.config.publicOrigin}/forgot-password`
+    : `${context.config.publicOrigin}/login`;
   await sendTemplatedEmail(context, {
     to: params.email,
     template: "signup_existing_account_notice",
     variables: {
       name: params.name || params.email,
-      recovery_link: `${context.config.publicOrigin}/login`,
+      recovery_link: recoveryLink,
     },
   });
 }

--- a/packages/api/src/services/passwordReset.test.ts
+++ b/packages/api/src/services/passwordReset.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { Context } from "../types.ts";
+import {
+  getPasswordResetTokenTtlMinutes,
+  normalizePasswordResetEmail,
+  PASSWORD_RESET_GENERIC_MESSAGE,
+  requestPasswordResetEmail,
+  shouldShowPasswordResetLink,
+} from "./passwordReset.ts";
+
+function createLogger() {
+  return {
+    error() {},
+    warn() {},
+    info() {},
+    debug() {},
+    trace() {},
+    fatal() {},
+  };
+}
+
+function createContext(values: unknown[]): Context {
+  let index = 0;
+  return {
+    db: {
+      query: {
+        settings: {
+          findFirst: async () => ({ value: values[index++] }),
+        },
+      },
+      insert: () => ({
+        values: async () => {},
+      }),
+    },
+    config: {
+      publicOrigin: "https://auth.example.com",
+    },
+    services: {},
+    logger: createLogger(),
+  } as unknown as Context;
+}
+
+test("getPasswordResetTokenTtlMinutes clamps out-of-range settings", async () => {
+  const low = createContext([1]);
+  const high = createContext([20000]);
+  const valid = createContext([120]);
+
+  assert.equal(await getPasswordResetTokenTtlMinutes(low), 5);
+  assert.equal(await getPasswordResetTokenTtlMinutes(high), 1440);
+  assert.equal(await getPasswordResetTokenTtlMinutes(valid), 120);
+});
+
+test("requestPasswordResetEmail returns generic success when disabled", async () => {
+  const context = createContext([false]);
+
+  const response = await requestPasswordResetEmail(context, {
+    email: " User@Example.COM ",
+    ipAddress: "127.0.0.1",
+    userAgent: "test-agent",
+  });
+
+  assert.deepEqual(response, { success: true, message: PASSWORD_RESET_GENERIC_MESSAGE });
+  assert.equal(normalizePasswordResetEmail(" User@Example.COM "), "user@example.com");
+});
+
+test("requestPasswordResetEmail returns generic success when smtp is unavailable", async () => {
+  const context = createContext([true, false]);
+
+  const response = await requestPasswordResetEmail(context, {
+    email: "user@example.com",
+    ipAddress: "127.0.0.1",
+  });
+
+  assert.deepEqual(response, { success: true, message: PASSWORD_RESET_GENERIC_MESSAGE });
+});
+
+test("shouldShowPasswordResetLink requires visible setting and available email", async () => {
+  const hidden = createContext([false]);
+  const visible = createContext([
+    true,
+    true,
+    true,
+    "smtp",
+    "DarkAuth <noreply@example.com>",
+    "smtp.example.com",
+    587,
+    "smtp-user",
+    "smtp-pass",
+  ]);
+
+  assert.equal(await shouldShowPasswordResetLink(hidden), false);
+  assert.equal(await shouldShowPasswordResetLink(visible), true);
+});

--- a/packages/api/src/services/passwordReset.ts
+++ b/packages/api/src/services/passwordReset.ts
@@ -1,0 +1,480 @@
+import { and, eq, gt, isNull, ne } from "drizzle-orm";
+import {
+  authCodes,
+  opaqueRecords,
+  passwordResetTokens,
+  pendingAuth,
+  sessions,
+  userOpaqueRecordHistory,
+  userPasswordHistory,
+  users,
+} from "../db/schema.ts";
+import { ConflictError, NotFoundError, ValidationError } from "../errors.ts";
+import {
+  countPasswordResetTokensSince,
+  createPasswordResetToken,
+  getActivePasswordResetToken,
+  getLatestPasswordResetTokenForUser,
+  hashPasswordResetToken,
+  invalidateActivePasswordResetTokens,
+} from "../models/passwordResetTokens.ts";
+import type { Context } from "../types.ts";
+import { toBase64Url } from "../utils/crypto.ts";
+import { logAuditEvent } from "./audit.ts";
+import { isEmailSendingAvailable, sendTemplatedEmail } from "./email.ts";
+import { getSetting } from "./settings.ts";
+
+export const PASSWORD_RESET_GENERIC_MESSAGE = "If an account exists, we sent reset instructions.";
+
+export function normalizePasswordResetEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function asNumberSetting(value: unknown, fallback: number, min: number, max: number): number {
+  const n = typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : fallback;
+  if (n < min) return min;
+  if (n > max) return max;
+  return n;
+}
+
+export async function getPasswordResetTokenTtlMinutes(context: Context): Promise<number> {
+  return asNumberSetting(
+    await getSetting(context, "users.password_reset_token_ttl_minutes"),
+    30,
+    5,
+    1440
+  );
+}
+
+async function getPasswordResetCooldownMinutes(context: Context): Promise<number> {
+  return asNumberSetting(
+    await getSetting(context, "users.password_reset_request_cooldown_minutes"),
+    5,
+    1,
+    60
+  );
+}
+
+async function getPasswordResetMaxRequestsPerHour(context: Context): Promise<number> {
+  return asNumberSetting(
+    await getSetting(context, "users.password_reset_max_requests_per_hour"),
+    3,
+    1,
+    20
+  );
+}
+
+export async function isPasswordResetEmailEnabled(context: Context): Promise<boolean> {
+  const enabled = (await getSetting(context, "users.password_reset_email_enabled")) === true;
+  if (!enabled) return false;
+  return isEmailSendingAvailable(context);
+}
+
+export async function shouldShowPasswordResetLink(context: Context): Promise<boolean> {
+  const showLink = (await getSetting(context, "users.password_reset_show_login_link")) !== false;
+  if (!showLink) return false;
+  return isPasswordResetEmailEnabled(context);
+}
+
+function maskEmail(email: string): string {
+  const [local = "", domain = ""] = email.split("@");
+  if (!domain) return "";
+  const visible = local.slice(0, 1);
+  return `${visible}${"*".repeat(Math.max(3, local.length - 1))}@${domain}`;
+}
+
+async function auditPasswordReset(
+  context: Context,
+  params: {
+    eventType: string;
+    ipAddress: string;
+    userAgent?: string;
+    userId?: string;
+    success: boolean;
+    errorMessage?: string;
+    details?: Record<string, unknown>;
+  }
+): Promise<void> {
+  await logAuditEvent(context, {
+    eventType: params.eventType,
+    cohort: "user",
+    userId: params.userId,
+    ipAddress: params.ipAddress,
+    userAgent: params.userAgent,
+    success: params.success,
+    errorMessage: params.errorMessage,
+    resourceType: "user",
+    resourceId: params.userId,
+    details: params.details,
+  });
+}
+
+async function sendPasswordResetTemplate(
+  context: Context,
+  user: { email: string; name?: string | null },
+  token: string,
+  ttlMinutes: number,
+  ipAddress: string
+): Promise<void> {
+  const resetLink = `${context.config.publicOrigin.replace(/\/+$/, "")}/reset-password?token=${encodeURIComponent(token)}`;
+  await sendTemplatedEmail(context, {
+    to: user.email,
+    template: "password_recovery",
+    variables: {
+      name: user.name || user.email,
+      email: user.email,
+      reset_link: resetLink,
+      recovery_link: resetLink,
+      expires_minutes: String(ttlMinutes),
+      requested_at: new Date().toISOString(),
+      ip_hint: ipAddress,
+    },
+  });
+}
+
+export async function requestPasswordResetEmail(
+  context: Context,
+  params: { email: string; ipAddress: string; userAgent?: string }
+): Promise<{ success: true; message: string }> {
+  const email = normalizePasswordResetEmail(params.email);
+  try {
+    if (!(await isPasswordResetEmailEnabled(context))) {
+      await auditPasswordReset(context, {
+        eventType: "USER_PASSWORD_RESET_EMAIL_SKIPPED",
+        ipAddress: params.ipAddress,
+        userAgent: params.userAgent,
+        success: true,
+        details: { reason: "disabled" },
+      });
+      return { success: true, message: PASSWORD_RESET_GENERIC_MESSAGE };
+    }
+
+    const user = await context.db.query.users.findFirst({ where: eq(users.email, email) });
+    if (!user || !user.email) {
+      return { success: true, message: PASSWORD_RESET_GENERIC_MESSAGE };
+    }
+
+    const requireEmailVerification =
+      (await getSetting(context, "users.require_email_verification")) === true;
+    if (requireEmailVerification && !user.emailVerifiedAt) {
+      await auditPasswordReset(context, {
+        eventType: "USER_PASSWORD_RESET_EMAIL_SKIPPED",
+        ipAddress: params.ipAddress,
+        userAgent: params.userAgent,
+        userId: user.sub,
+        success: true,
+        details: { reason: "unverified" },
+      });
+      return { success: true, message: PASSWORD_RESET_GENERIC_MESSAGE };
+    }
+
+    const cooldownMinutes = await getPasswordResetCooldownMinutes(context);
+    const latest = await getLatestPasswordResetTokenForUser(context, user.sub);
+    if (latest && latest.createdAt > new Date(Date.now() - cooldownMinutes * 60 * 1000)) {
+      await auditPasswordReset(context, {
+        eventType: "USER_PASSWORD_RESET_EMAIL_SKIPPED",
+        ipAddress: params.ipAddress,
+        userAgent: params.userAgent,
+        userId: user.sub,
+        success: true,
+        details: { reason: "cooldown" },
+      });
+      return { success: true, message: PASSWORD_RESET_GENERIC_MESSAGE };
+    }
+
+    const maxPerHour = await getPasswordResetMaxRequestsPerHour(context);
+    const count = await countPasswordResetTokensSince(
+      context,
+      user.sub,
+      new Date(Date.now() - 60 * 60 * 1000)
+    );
+    if (count >= maxPerHour) {
+      await auditPasswordReset(context, {
+        eventType: "USER_PASSWORD_RESET_RATE_LIMITED",
+        ipAddress: params.ipAddress,
+        userAgent: params.userAgent,
+        userId: user.sub,
+        success: false,
+      });
+      return { success: true, message: PASSWORD_RESET_GENERIC_MESSAGE };
+    }
+
+    const ttlMinutes = await getPasswordResetTokenTtlMinutes(context);
+    const { token } = await createPasswordResetToken(context, {
+      userSub: user.sub,
+      email: user.email,
+      ttlMinutes,
+      requestedIp: params.ipAddress,
+      userAgent: params.userAgent,
+    });
+    try {
+      await sendPasswordResetTemplate(
+        context,
+        { email: user.email, name: user.name },
+        token,
+        ttlMinutes,
+        params.ipAddress
+      );
+    } catch (error) {
+      await invalidateActivePasswordResetTokens(context, user.sub);
+      context.logger.warn(error, "Failed to send password reset email");
+      await auditPasswordReset(context, {
+        eventType: "USER_PASSWORD_RESET_EMAIL_SKIPPED",
+        ipAddress: params.ipAddress,
+        userAgent: params.userAgent,
+        userId: user.sub,
+        success: false,
+        errorMessage: error instanceof Error ? error.message : "Email send failed",
+        details: { reason: "smtp_failure" },
+      });
+      return { success: true, message: PASSWORD_RESET_GENERIC_MESSAGE };
+    }
+
+    await auditPasswordReset(context, {
+      eventType: "USER_PASSWORD_RESET_EMAIL_SENT",
+      ipAddress: params.ipAddress,
+      userAgent: params.userAgent,
+      userId: user.sub,
+      success: true,
+    });
+  } catch (error) {
+    context.logger.warn(error, "Password reset request failed");
+  }
+
+  return { success: true, message: PASSWORD_RESET_GENERIC_MESSAGE };
+}
+
+export async function sendAdminPasswordResetEmail(
+  context: Context,
+  params: {
+    userSub: string;
+    adminId: string;
+    ipAddress: string;
+    userAgent?: string;
+  }
+): Promise<{ success: true }> {
+  if (!(await isPasswordResetEmailEnabled(context))) {
+    throw new ValidationError(
+      "Password reset email cannot be sent until SMTP and password reset are enabled"
+    );
+  }
+  const user = await context.db.query.users.findFirst({ where: eq(users.sub, params.userSub) });
+  if (!user?.email) throw new NotFoundError("User not found");
+
+  const ttlMinutes = await getPasswordResetTokenTtlMinutes(context);
+  const { token } = await createPasswordResetToken(context, {
+    userSub: user.sub,
+    email: user.email,
+    ttlMinutes,
+    requestedIp: params.ipAddress,
+    userAgent: params.userAgent,
+  });
+
+  try {
+    await sendPasswordResetTemplate(
+      context,
+      { email: user.email, name: user.name },
+      token,
+      ttlMinutes,
+      params.ipAddress
+    );
+  } catch (error) {
+    await invalidateActivePasswordResetTokens(context, user.sub);
+    context.logger.warn(error, "Failed to send admin-triggered password reset email");
+    await logAuditEvent(context, {
+      eventType: "ADMIN_USER_PASSWORD_RESET_EMAIL_SENT",
+      cohort: "admin",
+      adminId: params.adminId,
+      ipAddress: params.ipAddress,
+      userAgent: params.userAgent,
+      success: false,
+      errorMessage: error instanceof Error ? error.message : "Email send failed",
+      resourceType: "user",
+      resourceId: user.sub,
+      details: { reason: "smtp_failure" },
+    });
+    throw new ValidationError("Password reset email could not be sent");
+  }
+
+  await logAuditEvent(context, {
+    eventType: "ADMIN_USER_PASSWORD_RESET_EMAIL_SENT",
+    cohort: "admin",
+    adminId: params.adminId,
+    ipAddress: params.ipAddress,
+    userAgent: params.userAgent,
+    success: true,
+    resourceType: "user",
+    resourceId: user.sub,
+  });
+
+  return { success: true };
+}
+
+export async function validatePasswordResetTokenForDisplay(
+  context: Context,
+  token: string
+): Promise<{ valid: boolean; email?: string }> {
+  try {
+    const row = await getActivePasswordResetToken(context, token);
+    return { valid: true, email: maskEmail(row.email) };
+  } catch {
+    return { valid: false };
+  }
+}
+
+export async function startPasswordResetRegistration(
+  context: Context,
+  params: { token: string; requestBuffer: Uint8Array; ipAddress: string; userAgent?: string }
+): Promise<{ message: string; serverPublicKey: string; identityU: string }> {
+  if (!context.services.opaque) throw new ValidationError("OPAQUE service not available");
+  let token: Awaited<ReturnType<typeof getActivePasswordResetToken>>;
+  try {
+    token = await getActivePasswordResetToken(context, params.token);
+  } catch {
+    await auditPasswordReset(context, {
+      eventType: "USER_PASSWORD_RESET_TOKEN_INVALID",
+      ipAddress: params.ipAddress,
+      userAgent: params.userAgent,
+      success: false,
+    });
+    throw new ValidationError("This password reset link is invalid or expired.");
+  }
+  const registrationResponse = await context.services.opaque.startRegistration(
+    params.requestBuffer,
+    token.email
+  );
+  return {
+    message: toBase64Url(Buffer.from(registrationResponse.message)),
+    serverPublicKey: toBase64Url(Buffer.from(registrationResponse.serverPublicKey)),
+    identityU: token.email,
+  };
+}
+
+export async function finishPasswordResetRegistration(
+  context: Context,
+  params: {
+    token: string;
+    recordBuffer: Uint8Array;
+    exportKeyHash: string;
+    ipAddress: string;
+    userAgent?: string;
+  }
+): Promise<{ success: true }> {
+  if (!context.services.opaque) throw new ValidationError("OPAQUE service not available");
+  let active: Awaited<ReturnType<typeof getActivePasswordResetToken>>;
+  try {
+    active = await getActivePasswordResetToken(context, params.token);
+  } catch {
+    await auditPasswordReset(context, {
+      eventType: "USER_PASSWORD_RESET_TOKEN_INVALID",
+      ipAddress: params.ipAddress,
+      userAgent: params.userAgent,
+      success: false,
+    });
+    throw new ValidationError("This password reset link is invalid or expired.");
+  }
+  const opaqueRecord = await context.services.opaque.finishRegistration(
+    params.recordBuffer,
+    active.email
+  );
+  const tokenHash = hashPasswordResetToken(context, params.token);
+  const now = new Date();
+  let userSub = active.userSub;
+
+  await context.db.transaction(async (tx) => {
+    const [token] = await tx
+      .update(passwordResetTokens)
+      .set({ consumedAt: now })
+      .where(
+        and(
+          eq(passwordResetTokens.tokenHash, tokenHash),
+          isNull(passwordResetTokens.consumedAt),
+          gt(passwordResetTokens.expiresAt, now)
+        )
+      )
+      .returning();
+    if (!token) throw new ValidationError("This password reset link is invalid or expired.");
+
+    userSub = token.userSub;
+    const user = await tx.query.users.findFirst({ where: eq(users.sub, token.userSub) });
+    if (!user || !user.email || user.email !== token.email) {
+      throw new ValidationError("This password reset link is invalid or expired.");
+    }
+
+    const anyMatch = await tx.query.userPasswordHistory.findFirst({
+      where: and(
+        eq(userPasswordHistory.userSub, token.userSub),
+        eq(userPasswordHistory.exportKeyHash, params.exportKeyHash)
+      ),
+    });
+    if (anyMatch) throw new ConflictError("Choose a password you have not used before.");
+
+    const existing = await tx.query.opaqueRecords.findFirst({
+      where: eq(opaqueRecords.sub, token.userSub),
+    });
+    if (existing) {
+      await tx
+        .insert(userOpaqueRecordHistory)
+        .values({
+          userSub: token.userSub,
+          envelope: existing.envelope,
+          serverPubkey: existing.serverPubkey,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: userOpaqueRecordHistory.userSub,
+          set: {
+            envelope: existing.envelope,
+            serverPubkey: existing.serverPubkey,
+            updatedAt: now,
+          },
+        });
+      await tx
+        .update(opaqueRecords)
+        .set({
+          envelope: Buffer.from(opaqueRecord.envelope),
+          serverPubkey: Buffer.from(opaqueRecord.serverPublicKey),
+          updatedAt: now,
+        })
+        .where(eq(opaqueRecords.sub, token.userSub));
+    } else {
+      await tx.insert(opaqueRecords).values({
+        sub: token.userSub,
+        envelope: Buffer.from(opaqueRecord.envelope),
+        serverPubkey: Buffer.from(opaqueRecord.serverPublicKey),
+        updatedAt: now,
+      });
+    }
+
+    await tx
+      .insert(userPasswordHistory)
+      .values({ userSub: token.userSub, exportKeyHash: params.exportKeyHash });
+    await tx
+      .update(users)
+      .set({ passwordResetRequired: false })
+      .where(eq(users.sub, token.userSub));
+    await tx
+      .update(passwordResetTokens)
+      .set({ consumedAt: now })
+      .where(
+        and(
+          eq(passwordResetTokens.userSub, token.userSub),
+          ne(passwordResetTokens.id, token.id),
+          isNull(passwordResetTokens.consumedAt)
+        )
+      );
+    await tx.delete(sessions).where(eq(sessions.userSub, token.userSub));
+    await tx.delete(authCodes).where(eq(authCodes.userSub, token.userSub));
+    await tx.delete(pendingAuth).where(eq(pendingAuth.userSub, token.userSub));
+  });
+
+  await auditPasswordReset(context, {
+    eventType: "USER_PASSWORD_RESET_COMPLETED",
+    ipAddress: params.ipAddress,
+    userAgent: params.userAgent,
+    userId: userSub,
+    success: true,
+  });
+
+  return { success: true };
+}

--- a/packages/api/src/utils/security.ts
+++ b/packages/api/src/utils/security.ts
@@ -74,6 +74,8 @@ export const DEFAULT_RATE_LIMITS = {
   otp_disable: { windowMs: 60 * 60 * 1000, maxRequests: 5, enabled: true },
   otp_regenerate: { windowMs: 60 * 60 * 1000, maxRequests: 5, enabled: true },
 
+  password_reset: { windowMs: 60 * 60 * 1000, maxRequests: 10, enabled: true },
+
   // Install endpoint
   install: { windowMs: 60 * 60 * 1000, maxRequests: 3, enabled: true },
 };
@@ -116,6 +118,7 @@ export async function getRateLimitConfig(
         "otp_verify",
         "otp_disable",
         "otp_regenerate",
+        "password_reset",
       ];
       for (const t of types) {
         const w = (await getSetting(context, `rate_limits.${t}.window_minutes`)) as

--- a/packages/brochureware/public/whitepaper.generated.md
+++ b/packages/brochureware/public/whitepaper.generated.md
@@ -2,7 +2,7 @@
 
 A technical analysis of zero‑knowledge key delivery for OIDC
 
-_2026-05-17_
+_2026-05-25_
 
 # DarkAuth v1 Security Whitepaper
 
@@ -174,6 +174,7 @@ User/OIDC (port 9080)
 - `POST /api/token` (form): authorization_code; returns `zk_drk_hash` when applicable
 - `POST /opaque/login/start`, `POST /opaque/login/finish`
 - `POST /opaque/register/start`, `POST /opaque/register/finish`
+- `POST /password/reset/request`, `GET /password/reset/token`, `POST /password/reset/start`, `POST /password/reset/finish`
 - `POST /password/change/verify/start`, `POST /password/change/verify/finish`
 - `POST /password/change/start`, `POST /password/change/finish`
 - `GET /crypto/wrapped-drk`, `PUT /crypto/wrapped-drk`
@@ -196,6 +197,10 @@ Constraints
 
 Password secrecy (OPAQUE)
 - Passwords are not sent to the server in the OPAQUE flow; verifiers do not allow offline recovery by themselves. Login finish binds the authenticated account to server‑tracked identity; enumeration resistance and rate limits are applied.
+
+Email reset safety
+- Self-service email reset is SMTP-gated and returns generic request responses to avoid account enumeration. Reset tokens are high-entropy, single-use, short-lived, and stored only as keyed hashes. Successful reset replaces the OPAQUE record and revokes active sessions and pending grants.
+- Email reset restores account access, not encrypted data. If DRK-wrapped material was derived from the previous password export key, users must use old-password recovery or generate new keys after signing in with the new password.
 
 DRK secrecy
 - Only wrapped DRK is stored. Without KW (derived from export_key on the device), the server cannot decrypt DRK from stored state during honest frontend operation.

--- a/packages/brochureware/src/App.tsx
+++ b/packages/brochureware/src/App.tsx
@@ -25,6 +25,7 @@ import ConfidentialClientFlowPage from "./pages/docs/guides/ConfidentialClientFl
 import UsersDirectoryGuidePage from "./pages/docs/guides/UsersDirectory";
 import OrganizationsRbacPage from "./pages/docs/guides/OrganizationsRbac";
 import OtpPolicyPage from "./pages/docs/guides/OtpPolicy";
+import PasswordResetPage from "./pages/docs/guides/PasswordReset";
 import ApiOverviewPage from "./pages/docs/api/ApiOverview";
 import ApiAuthPage from "./pages/docs/api/Auth";
 import ApiOpaquePage from "./pages/docs/api/Opaque";
@@ -73,6 +74,7 @@ const App = () => (
             <Route path="guides/users-directory" element={<UsersDirectoryGuidePage />} />
             <Route path="guides/organizations-rbac" element={<OrganizationsRbacPage />} />
             <Route path="guides/otp-policy" element={<OtpPolicyPage />} />
+            <Route path="guides/password-reset" element={<PasswordResetPage />} />
             <Route path="api" element={<ApiOverviewPage />} />
             <Route path="api/overview" element={<ApiOverviewPage />} />
             <Route path="api/auth" element={<ApiAuthPage />} />

--- a/packages/brochureware/src/components/Features.tsx
+++ b/packages/brochureware/src/components/Features.tsx
@@ -7,6 +7,7 @@ import {
   Database, 
   Settings, 
   Lock,
+  MailCheck,
   RefreshCw,
   Users,
   Globe
@@ -62,6 +63,13 @@ const Features = () => {
       description: "Separate admin (9081) and user (9080) interfaces with different access controls",
       badge: "Secure by Design",
       color: "text-primary"
+    },
+    {
+      icon: MailCheck,
+      title: "Safe Email Recovery",
+      description: "Forgot-password links use generic responses, hashed one-time tokens, audit logs, and session revocation",
+      badge: "Account Recovery",
+      color: "text-accent"
     },
     {
       icon: Zap,

--- a/packages/brochureware/src/pages/Features.tsx
+++ b/packages/brochureware/src/pages/Features.tsx
@@ -2,7 +2,7 @@ import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Check, Shield, Lock, KeyRound, Hash, RefreshCcw, Users, Settings, BookOpenCheck, ServerCog } from "lucide-react";
+import { Check, Shield, Lock, KeyRound, Hash, RefreshCcw, Users, Settings, BookOpenCheck, ServerCog, MailCheck } from "lucide-react";
 
 type Feature = {
   icon: React.ComponentType<{ className?: string }>;
@@ -41,6 +41,16 @@ const features: Feature[] = [
       "AMR includes otp; ACR indicates MFA",
     ],
     tags: ["OTP", "TOTP", "MFA"],
+  },
+  {
+    icon: MailCheck,
+    title: "Email Password Reset",
+    bullets: [
+      "SMTP-gated forgot-password flow",
+      "HMAC-hashed one-time reset tokens",
+      "Session and pending grant revocation after reset",
+    ],
+    tags: ["Recovery", "SMTP", "OPAQUE"],
   },
   {
     icon: Lock,

--- a/packages/brochureware/src/pages/Security.tsx
+++ b/packages/brochureware/src/pages/Security.tsx
@@ -3,7 +3,7 @@ import Footer from "@/components/Footer";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { ShieldCheck, Lock, KeySquare, EyeOff, Hash, Network, BookCheck, TriangleAlert, ListChecks } from "lucide-react";
+import { ShieldCheck, Lock, KeySquare, EyeOff, Hash, Network, BookCheck, TriangleAlert, ListChecks, MailCheck } from "lucide-react";
 
 const Section = ({ children, className = "" }: { children: React.ReactNode; className?: string }) => (
   <section className={`py-16 ${className}`}>
@@ -62,6 +62,7 @@ const SecurityPage = () => {
           <KeyPoint icon={EyeOff} title="No Sensitive Logging" text="zk_pub, DRK, JWE ciphertext, export_key, and derived keys are never logged." />
           <KeyPoint icon={Network} title="OIDC Compatibility" text="Standard discovery, authorization, and token endpoints; ZK is opt-in per client." />
           <KeyPoint icon={ShieldCheck} title="MFA via TOTP" text="Time-based OTP with backup codes, cohort and group enforcement, rate limits, and AMR/ACR signals in tokens." />
+          <KeyPoint icon={MailCheck} title="Email Reset Without Enumeration" text="Reset requests return generic responses, tokens are HMAC-hashed at rest, and successful reset revokes active sessions." />
         </div>
       </Section>
 
@@ -80,6 +81,7 @@ const SecurityPage = () => {
                 <li>Token endpoint key exfiltration: server never stores or returns DRK JWE.</li>
                 <li>Redirect tampering: clients verify zk_drk_hash before using DRK.</li>
                 <li>Weak ECDH keys: public keys are validated for P-256 format and length.</li>
+                <li>Reset token table theft: email reset stores only keyed hashes, not plaintext links.</li>
               </ul>
             </CardContent>
           </Card>
@@ -184,6 +186,12 @@ const SecurityPage = () => {
             <CardContent className="p-6">
               <h3 className="font-semibold mb-2">Does changing my password break apps?</h3>
               <p className="text-sm text-muted-foreground">No. You rewrap the same DRK under a new device-derived key. Apps keep decrypting the same data.</p>
+            </CardContent>
+          </Card>
+          <Card className="bg-card border-border/50">
+            <CardContent className="p-6">
+              <h3 className="font-semibold mb-2">Does email reset recover encrypted data?</h3>
+              <p className="text-sm text-muted-foreground">No. It restores sign-in access. Old encrypted data may still need old-password recovery or fresh key generation.</p>
             </CardContent>
           </Card>
           <Card className="bg-card border-border/50">

--- a/packages/brochureware/src/pages/docs/Introduction.tsx
+++ b/packages/brochureware/src/pages/docs/Introduction.tsx
@@ -1,7 +1,7 @@
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import DocsCallout from "@/pages/docs/components/DocsCallout";
-import { Lock, ShieldCheck, ServerCog, Users } from "lucide-react";
+import { KeyRound, Lock, ShieldCheck, ServerCog, Users } from "lucide-react";
 
 const IntroductionPage = () => {
   return (
@@ -84,15 +84,16 @@ const IntroductionPage = () => {
         <Card className="border-border/60 shadow-sm">
           <CardContent className="p-6 space-y-3">
             <div className="mb-1 flex items-center gap-2 text-foreground">
-              <Lock className="h-5 w-5 text-primary" />
-              <h3 className="font-semibold">Integrator-First Surface</h3>
+              <KeyRound className="h-5 w-5 text-primary" />
+              <h3 className="font-semibold">Account Recovery Boundaries</h3>
             </div>
             <p className="text-base text-muted-foreground">
-              Use guide flows for frontend OAuth integration, confidential backend clients, SDK usage,
-              and endpoint-level reference for API contracts.
+              Email password reset restores account access through OPAQUE reset, while encrypted data
+              recovery remains a separate old-password or key-regeneration path.
             </p>
             <p className="text-sm text-muted-foreground">
-              Each page maps to concrete routes in `packages/api` and is tested through Playwright flows.
+              SMTP, generic responses, hashed reset tokens, and session revocation are covered in the
+              dedicated guide.
             </p>
           </CardContent>
         </Card>

--- a/packages/brochureware/src/pages/docs/Quickstart.tsx
+++ b/packages/brochureware/src/pages/docs/Quickstart.tsx
@@ -67,6 +67,14 @@ kekPassphrase: "replace-with-strong-pass"`}</code>
         </ol>
       </DocsCallout>
 
+      <DocsCallout title="Optional email recovery setup" icon={CheckCircle2}>
+        <ol className="list-decimal space-y-2 pl-5 text-base">
+          <li>Configure SMTP settings in the admin UI.</li>
+          <li>Enable `Users / Password Reset` once SMTP is complete.</li>
+          <li>Customize the `password_recovery` email template before inviting real users.</li>
+        </ol>
+      </DocsCallout>
+
       <Card className="border-border/60 shadow-sm">
         <CardHeader>
           <CardTitle className="text-lg">3) Recommended local dev setup</CardTitle>

--- a/packages/brochureware/src/pages/docs/api/ApiOverview.tsx
+++ b/packages/brochureware/src/pages/docs/api/ApiOverview.tsx
@@ -30,6 +30,7 @@ const ApiOverviewPage = () => {
             <ul className="list-disc space-y-2 pl-5 text-base text-muted-foreground">
               <li>Auth flows: `/api/authorize`, `/api/token`, `/api/session`, `/api/logout`.</li>
               <li>Identity: OPAQUE start/finish for register and login.</li>
+              <li>Account recovery: email reset request, token validation, and OPAQUE reset.</li>
               <li>Directory and org endpoints for consuming apps and user surfaces.</li>
               <li>Public/Opaque crypto endpoints for wrapped key operations.</li>
             </ul>

--- a/packages/brochureware/src/pages/docs/api/Auth.tsx
+++ b/packages/brochureware/src/pages/docs/api/Auth.tsx
@@ -19,6 +19,7 @@ const tokenRefreshSnippet = `POST /api/token\nContent-Type: application/x-www-fo
 
 const sessionSnippet = `GET /api/session\nAuthorization: Bearer <access_token>`;
 const logoutSnippet = `POST /api/logout\nAuthorization: Bearer <access_token>`;
+const passwordResetSnippet = `POST /api/password/reset/request\nContent-Type: application/json\n\n{"email":"alice@example.com"}`;
 
 const AuthPage = () => {
   return (
@@ -104,6 +105,22 @@ const AuthPage = () => {
           <li>When `organization_id` is omitted, DarkAuth uses the current session org, selects the only active org, or prompts multi-org users before code issue.</li>
         </ul>
       </DocsCallout>
+
+      <Card className="border-border/60 shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-lg">Email password reset</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <pre className="overflow-x-auto rounded-md border border-border/60 bg-muted/50 p-4 text-xs">
+            <code>{passwordResetSnippet}</code>
+          </pre>
+          <p className="mt-3 text-sm text-muted-foreground">
+            Reset requests always return a generic response. The reset page uses `/api/password/reset/token`,
+            `/api/password/reset/start`, and `/api/password/reset/finish` to validate and replace the
+            OPAQUE password record.
+          </p>
+        </CardContent>
+      </Card>
 
       <Card className="border-border/60 shadow-sm">
         <CardHeader>

--- a/packages/brochureware/src/pages/docs/concepts/SecurityModel.tsx
+++ b/packages/brochureware/src/pages/docs/concepts/SecurityModel.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { ShieldAlert, RefreshCcw, KeyRound } from "lucide-react";
+import { ShieldAlert, RefreshCcw, KeyRound, MailCheck } from "lucide-react";
 import DocsCallout from "@/pages/docs/components/DocsCallout";
 
 const SecurityModelPage = () => {
@@ -56,6 +56,20 @@ const SecurityModelPage = () => {
             <p className="text-base text-muted-foreground">
               Middleware applies origin checks on non-idempotent requests, CSP-style headers, and token
               checks before business logic. OTP policies can force re-auth at sensitive operations.
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="border-border/50 md:col-span-2">
+          <CardContent className="p-6">
+            <div className="mb-3 flex items-center gap-2 text-foreground">
+              <MailCheck className="h-5 w-5 text-primary" />
+              <h3 className="font-semibold">Email reset is account recovery</h3>
+            </div>
+            <p className="text-base text-muted-foreground">
+              Forgot-password links are SMTP-gated, generic-response, and one-time. They create a new
+              OPAQUE password record and revoke sessions, but they do not decrypt data wrapped under
+              the previous password-derived key.
             </p>
           </CardContent>
         </Card>

--- a/packages/brochureware/src/pages/docs/docsNavigation.ts
+++ b/packages/brochureware/src/pages/docs/docsNavigation.ts
@@ -79,6 +79,11 @@ export const docsSections: DocsSection[] = [
         path: "/docs/guides/otp-policy",
         description: "Step-up auth and OTP setup/verification flows.",
       },
+      {
+        title: "Email Password Reset",
+        path: "/docs/guides/password-reset",
+        description: "SMTP-gated reset links, OPAQUE reset, and encrypted-data recovery limits.",
+      },
     ],
   },
   {

--- a/packages/brochureware/src/pages/docs/guides/PasswordReset.tsx
+++ b/packages/brochureware/src/pages/docs/guides/PasswordReset.tsx
@@ -1,0 +1,116 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import DocsCallout from "@/pages/docs/components/DocsCallout";
+import { KeyRound, Mail, ShieldCheck, TriangleAlert } from "lucide-react";
+
+const requestExample = `POST /api/password/reset/request
+Content-Type: application/json
+
+{"email":"alice@example.com"}`;
+
+const startExample = `POST /api/password/reset/start
+Content-Type: application/json
+
+{"token":"RESET_TOKEN","request":"BASE64URL-OPAQUE-REQUEST"}`;
+
+const finishExample = `POST /api/password/reset/finish
+Content-Type: application/json
+
+{"token":"RESET_TOKEN","record":"BASE64URL-OPAQUE-RECORD","export_key_hash":"BASE64URL-SHA256"}`;
+
+const PasswordResetPage = () => {
+  return (
+    <div className="space-y-8">
+      <Card className="border-border/60 shadow-sm">
+        <CardHeader>
+          <Badge variant="outline" className="mb-2 border-primary/30 text-primary">
+            Guide: Email Password Reset
+          </Badge>
+          <CardTitle className="text-2xl">Self-service recovery without account leaks</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-base text-muted-foreground">
+            DarkAuth can email users a single-use reset link when SMTP is configured and the admin
+            setting is enabled. The request path always returns the same generic response so unknown
+            addresses, disabled reset, and SMTP failures do not reveal account state.
+          </p>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <Card className="border-border/60 shadow-sm">
+          <CardContent className="p-6 space-y-3">
+            <div className="mb-1 flex items-center gap-2 text-foreground">
+              <Mail className="h-5 w-5 text-primary" />
+              <h3 className="font-semibold">Enablement</h3>
+            </div>
+            <ul className="list-disc space-y-2 pl-5 text-base text-muted-foreground">
+              <li>Configure and enable SMTP under Admin Settings.</li>
+              <li>Enable `users.password_reset_email_enabled`.</li>
+              <li>Customize `email.templates.password_recovery` if needed.</li>
+            </ul>
+          </CardContent>
+        </Card>
+
+        <Card className="border-border/60 shadow-sm">
+          <CardContent className="p-6 space-y-3">
+            <div className="mb-1 flex items-center gap-2 text-foreground">
+              <ShieldCheck className="h-5 w-5 text-primary" />
+              <h3 className="font-semibold">Token handling</h3>
+            </div>
+            <ul className="list-disc space-y-2 pl-5 text-base text-muted-foreground">
+              <li>Tokens are high entropy, one-time, and short-lived.</li>
+              <li>Only HMAC-SHA-256 token hashes are stored.</li>
+              <li>Successful reset revokes active sessions and pending grants.</li>
+            </ul>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="border-border/60 shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-lg">Endpoint flow</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <pre className="overflow-x-auto rounded-md border border-border/60 bg-muted/50 p-4 text-xs">
+            <code>{requestExample}</code>
+          </pre>
+          <pre className="overflow-x-auto rounded-md border border-border/60 bg-muted/50 p-4 text-xs">
+            <code>{startExample}</code>
+          </pre>
+          <pre className="overflow-x-auto rounded-md border border-border/60 bg-muted/50 p-4 text-xs">
+            <code>{finishExample}</code>
+          </pre>
+        </CardContent>
+      </Card>
+
+      <DocsCallout title="Zero-knowledge boundary" icon={TriangleAlert}>
+        <p className="text-base">
+          Email password reset restores account access; it does not decrypt data wrapped under the
+          old password-derived export key. After signing in with the new password, users may need the
+          existing old-password recovery flow or may need to generate fresh keys.
+        </p>
+      </DocsCallout>
+
+      <Card className="border-border/60 shadow-sm">
+        <CardContent className="p-6">
+          <div className="mb-3 flex items-center gap-2 text-foreground">
+            <KeyRound className="h-5 w-5 text-primary" />
+            <h3 className="font-semibold">Template variables</h3>
+          </div>
+          <p className="text-base text-muted-foreground">
+            The reset email supports `name`, `email`, `reset_link`, `recovery_link`,
+            `expires_minutes`, `requested_at`, and `ip_hint`. `recovery_link` remains an alias for
+            older customized templates.
+          </p>
+          <p className="mt-3 text-base text-muted-foreground">
+            Write admins can also send a reset email from the user detail page. The token is still
+            only delivered by email and is never displayed in the admin UI.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default PasswordResetPage;

--- a/packages/test-suite/setup/server.ts
+++ b/packages/test-suite/setup/server.ts
@@ -15,6 +15,7 @@ export interface TestServers {
   adminServer: ReturnType<typeof createServer>;
   userServer: ReturnType<typeof createServer>;
   context: Context;
+  getContext: () => Context;
   adminPort: number;
   userPort: number;
   adminUrl: string;
@@ -71,6 +72,7 @@ export async function createTestServers(config: TestServerConfig): Promise<TestS
     adminServer,
     userServer,
     context,
+    getContext: app.getContext,
     adminPort,
     userPort,
     adminUrl: `http://localhost:${adminPort}`,

--- a/packages/test-suite/tests/api/password-reset.spec.ts
+++ b/packages/test-suite/tests/api/password-reset.spec.ts
@@ -1,0 +1,383 @@
+import { expect, test } from '@playwright/test';
+import { OpaqueClient } from '@DarkAuth/api/src/lib/opaque/opaque-ts-wrapper.ts';
+import { userPasswordHistory } from '@DarkAuth/api/src/db/schema.ts';
+import { createPasswordResetToken } from '@DarkAuth/api/src/models/passwordResetTokens.ts';
+import { fromBase64Url, sha256Base64Url, toBase64Url } from '@DarkAuth/api/src/utils/crypto.ts';
+import { FIXED_TEST_ADMIN } from '../../fixtures/testData.js';
+import { createUserViaAdmin, getAdminSession } from '../../setup/helpers/auth.js';
+import { installDarkAuth } from '../../setup/install.js';
+import { createTestServers, destroyTestServers, type TestServers } from '../../setup/server.js';
+
+const genericMessage = 'If an account exists, we sent reset instructions.';
+
+function getCookieHeader(response: import('@playwright/test').APIResponse) {
+  return response
+    .headersArray()
+    .filter((header) => header.name.toLowerCase() === 'set-cookie')
+    .map((header) => header.value.split(';')[0])
+    .join('; ');
+}
+
+async function opaqueLogin(
+  servers: TestServers,
+  email: string,
+  password: string,
+  request: import('@playwright/test').APIRequestContext
+) {
+  const client = new OpaqueClient();
+  await client.initialize();
+  const start = await client.startLogin(password, email);
+  const startResponse = await request.post(`${servers.userUrl}/api/user/opaque/login/start`, {
+    headers: { Origin: servers.userUrl, 'Content-Type': 'application/json' },
+    data: {
+      email,
+      request: toBase64Url(Buffer.from(start.request)),
+    },
+  });
+  if (!startResponse.ok()) {
+    return {
+      status: startResponse.status(),
+      json: await startResponse.json().catch(() => null),
+      cookieHeader: '',
+    };
+  }
+  const startJson = await startResponse.json();
+  let finish;
+  try {
+    finish = await client.finishLogin(
+      fromBase64Url(startJson.message),
+      start.state,
+      new Uint8Array(),
+      'DarkAuth',
+      email
+    );
+  } catch (error) {
+    return {
+      status: 401,
+      json: { error: error instanceof Error ? error.message : String(error) },
+      cookieHeader: '',
+    };
+  }
+  const finishResponse = await request.post(`${servers.userUrl}/api/user/opaque/login/finish`, {
+    headers: { Origin: servers.userUrl, 'Content-Type': 'application/json' },
+    data: {
+      finish: toBase64Url(Buffer.from(finish.finish)),
+      sessionId: startJson.sessionId,
+    },
+  });
+  const json = await finishResponse.json().catch(() => null);
+  return {
+    status: finishResponse.status(),
+    json,
+    cookieHeader: getCookieHeader(finishResponse),
+  };
+}
+
+async function resetPasswordWithToken(
+  servers: TestServers,
+  token: string,
+  email: string,
+  password: string,
+  request: import('@playwright/test').APIRequestContext,
+  beforeFinish?: (exportKeyHash: string) => Promise<void>
+) {
+  const client = new OpaqueClient();
+  await client.initialize();
+  const registration = await client.startRegistration(password, email);
+  const startResponse = await request.post(`${servers.userUrl}/api/user/password/reset/start`, {
+    headers: { Origin: servers.userUrl, 'Content-Type': 'application/json' },
+    data: {
+      token,
+      request: toBase64Url(Buffer.from(registration.request)),
+    },
+  });
+  const startJson = await startResponse.json().catch(() => null);
+  if (!startResponse.ok()) {
+    return { startStatus: startResponse.status(), finishStatus: 0, startJson, finishJson: null };
+  }
+  expect(startJson.identityU).toBe(email);
+  const finish = await client.finishRegistration(
+    fromBase64Url(startJson.message),
+    registration.state,
+    fromBase64Url(startJson.serverPublicKey),
+    'DarkAuth',
+    startJson.identityU
+  );
+  const exportKeyHash = sha256Base64Url(Buffer.from(finish.export_key));
+  await beforeFinish?.(exportKeyHash);
+  const finishResponse = await request.post(`${servers.userUrl}/api/user/password/reset/finish`, {
+    headers: { Origin: servers.userUrl, 'Content-Type': 'application/json' },
+    data: {
+      token,
+      record: toBase64Url(Buffer.from(finish.upload)),
+      export_key_hash: exportKeyHash,
+    },
+  });
+  const finishJson = await finishResponse.json().catch(() => null);
+  return {
+    startStatus: startResponse.status(),
+    finishStatus: finishResponse.status(),
+    startJson,
+    finishJson,
+  };
+}
+
+async function updateAdminSetting(
+  servers: TestServers,
+  key: string,
+  value: unknown,
+  request: import('@playwright/test').APIRequestContext
+) {
+  const adminSession = await getAdminSession(servers, {
+    email: FIXED_TEST_ADMIN.email,
+    password: FIXED_TEST_ADMIN.password,
+  });
+  return request.put(`${servers.adminUrl}/admin/settings`, {
+    headers: {
+      Origin: servers.adminUrl,
+      Cookie: adminSession.cookieHeader,
+      'x-csrf-token': adminSession.csrfToken,
+    },
+    data: { key, value },
+  });
+}
+
+test.describe('API - Password reset', () => {
+  let servers: TestServers;
+
+  test.beforeAll(async () => {
+    servers = await createTestServers({ testName: 'api-password-reset' });
+    await installDarkAuth({
+      adminUrl: servers.adminUrl,
+      adminEmail: FIXED_TEST_ADMIN.email,
+      adminName: FIXED_TEST_ADMIN.name,
+      adminPassword: FIXED_TEST_ADMIN.password,
+      installToken: 'test-install-token',
+    });
+  });
+
+  test.afterAll(async () => {
+    if (servers) await destroyTestServers(servers);
+  });
+
+  test('request endpoint returns the same generic response for existing and unknown emails', async ({
+    request,
+  }) => {
+    const user = {
+      email: `reset-request-${Date.now()}@example.com`,
+      name: 'Reset Request',
+      password: 'Passw0rd!ResetRequest',
+    };
+    await createUserViaAdmin(
+      servers,
+      { email: FIXED_TEST_ADMIN.email, password: FIXED_TEST_ADMIN.password },
+      user
+    );
+
+    const known = await request.post(`${servers.userUrl}/api/user/password/reset/request`, {
+      headers: { Origin: servers.userUrl, 'Content-Type': 'application/json' },
+      data: { email: ` ${user.email.toUpperCase()} ` },
+    });
+    const unknown = await request.post(`${servers.userUrl}/api/user/password/reset/request`, {
+      headers: { Origin: servers.userUrl, 'Content-Type': 'application/json' },
+      data: { email: `missing-${Date.now()}@example.com` },
+    });
+
+    expect(known.status()).toBe(200);
+    expect(unknown.status()).toBe(200);
+    await expect(known.json()).resolves.toEqual({ success: true, message: genericMessage });
+    await expect(unknown.json()).resolves.toEqual({ success: true, message: genericMessage });
+  });
+
+  test('admin settings reject unsafe password reset configuration', async ({ request }) => {
+    const invalidTtl = await updateAdminSetting(
+      servers,
+      'users.password_reset_token_ttl_minutes',
+      4,
+      request
+    );
+    expect(invalidTtl.status()).toBe(400);
+    expect(await invalidTtl.json()).toMatchObject({
+      error: 'Password reset token TTL must be between 5 and 1440 minutes',
+    });
+
+    const blockedEnable = await updateAdminSetting(
+      servers,
+      'users.password_reset_email_enabled',
+      true,
+      request
+    );
+    expect(blockedEnable.status()).toBe(400);
+    expect(await blockedEnable.json()).toMatchObject({
+      error: 'Password reset cannot be enabled until SMTP is configured and enabled',
+    });
+  });
+
+  test('admin reset email action requires configured email reset', async ({ request }) => {
+    const user = {
+      email: `reset-admin-send-${Date.now()}@example.com`,
+      name: 'Reset Admin Send',
+      password: 'Passw0rd!ResetAdminSend',
+    };
+    const { sub } = await createUserViaAdmin(
+      servers,
+      { email: FIXED_TEST_ADMIN.email, password: FIXED_TEST_ADMIN.password },
+      user
+    );
+    const adminSession = await getAdminSession(servers, {
+      email: FIXED_TEST_ADMIN.email,
+      password: FIXED_TEST_ADMIN.password,
+    });
+
+    const response = await request.post(
+      `${servers.adminUrl}/admin/users/${encodeURIComponent(sub)}/password/reset-email`,
+      {
+        headers: {
+          Origin: servers.adminUrl,
+          Cookie: adminSession.cookieHeader,
+          'x-csrf-token': adminSession.csrfToken,
+        },
+      }
+    );
+    expect(response.status()).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: 'Password reset email cannot be sent until SMTP and password reset are enabled',
+    });
+  });
+
+  test('token validation exposes only validity and masked email', async ({ request }) => {
+    const user = {
+      email: `reset-token-${Date.now()}@example.com`,
+      name: 'Reset Token',
+      password: 'Passw0rd!ResetToken',
+    };
+    const { sub } = await createUserViaAdmin(
+      servers,
+      { email: FIXED_TEST_ADMIN.email, password: FIXED_TEST_ADMIN.password },
+      user
+    );
+    const created = await createPasswordResetToken(servers.getContext(), {
+      userSub: sub,
+      email: user.email,
+      ttlMinutes: 30,
+    });
+
+    const valid = await request.get(
+      `${servers.userUrl}/api/user/password/reset/token?token=${encodeURIComponent(created.token)}`,
+      { headers: { Origin: servers.userUrl } }
+    );
+    const validJson = await valid.json();
+    expect(valid.status()).toBe(200);
+    expect(validJson.valid).toBe(true);
+    expect(validJson.email).not.toBe(user.email);
+    expect(validJson.email).toContain('@example.com');
+    expect(validJson.sub).toBeUndefined();
+    expect(validJson.userSub).toBeUndefined();
+
+    const invalid = await request.get(
+      `${servers.userUrl}/api/user/password/reset/token?token=missing-${Date.now()}`,
+      { headers: { Origin: servers.userUrl } }
+    );
+    await expect(invalid.json()).resolves.toEqual({ valid: false });
+  });
+
+  test('finish rejects password reuse without consuming the token', async ({ request }) => {
+    const user = {
+      email: `reset-reuse-${Date.now()}@example.com`,
+      name: 'Reset Reuse',
+      password: 'Passw0rd!ResetReuse',
+    };
+    const { sub } = await createUserViaAdmin(
+      servers,
+      { email: FIXED_TEST_ADMIN.email, password: FIXED_TEST_ADMIN.password },
+      user
+    );
+    const created = await createPasswordResetToken(servers.getContext(), {
+      userSub: sub,
+      email: user.email,
+      ttlMinutes: 30,
+    });
+
+    const reuse = await resetPasswordWithToken(
+      servers,
+      created.token,
+      user.email,
+      user.password,
+      request,
+      async (exportKeyHash) => {
+        await servers.getContext().db.insert(userPasswordHistory).values({
+          userSub: sub,
+          exportKeyHash,
+        });
+      }
+    );
+
+    expect(reuse.startStatus).toBe(200);
+    expect(reuse.finishStatus).toBe(409);
+    expect(reuse.finishJson?.error).toBe('Choose a password you have not used before.');
+
+    const token = await request.get(
+      `${servers.userUrl}/api/user/password/reset/token?token=${encodeURIComponent(created.token)}`,
+      { headers: { Origin: servers.userUrl } }
+    );
+    expect(await token.json()).toMatchObject({ valid: true });
+  });
+
+  test('successful reset makes old password fail, new password succeed, and old session invalid', async ({
+    request,
+  }) => {
+    const user = {
+      email: `reset-flow-${Date.now()}@example.com`,
+      name: 'Reset Flow',
+      password: 'Passw0rd!ResetFlow',
+    };
+    const newPassword = 'Passw0rd!ResetFlowNew';
+    const { sub } = await createUserViaAdmin(
+      servers,
+      { email: FIXED_TEST_ADMIN.email, password: FIXED_TEST_ADMIN.password },
+      user
+    );
+    const oldLogin = await opaqueLogin(servers, user.email, user.password, request);
+    expect(oldLogin.status).toBe(200);
+    expect(oldLogin.cookieHeader).toContain('__Host-DarkAuth-User=');
+
+    const sessionBefore = await request.get(`${servers.userUrl}/api/user/session`, {
+      headers: { Origin: servers.userUrl, Cookie: oldLogin.cookieHeader },
+    });
+    expect(sessionBefore.status()).toBe(200);
+
+    const created = await createPasswordResetToken(servers.getContext(), {
+      userSub: sub,
+      email: user.email,
+      ttlMinutes: 30,
+    });
+    const reset = await resetPasswordWithToken(
+      servers,
+      created.token,
+      user.email,
+      newPassword,
+      request
+    );
+    expect(reset.startStatus).toBe(200);
+    expect(reset.finishStatus).toBe(200);
+    expect(reset.finishJson).toEqual({ success: true });
+
+    const consumed = await request.get(
+      `${servers.userUrl}/api/user/password/reset/token?token=${encodeURIComponent(created.token)}`,
+      { headers: { Origin: servers.userUrl } }
+    );
+    expect(await consumed.json()).toEqual({ valid: false });
+
+    const oldPasswordLogin = await opaqueLogin(servers, user.email, user.password, request);
+    expect(oldPasswordLogin.status).not.toBe(200);
+
+    const newPasswordLogin = await opaqueLogin(servers, user.email, newPassword, request);
+    expect(newPasswordLogin.status).toBe(200);
+    expect(newPasswordLogin.json?.success).toBe(true);
+
+    const oldSession = await request.get(`${servers.userUrl}/api/user/session`, {
+      headers: { Origin: servers.userUrl, Cookie: oldLogin.cookieHeader },
+    });
+    expect(oldSession.status()).toBe(401);
+  });
+});

--- a/packages/test-suite/tests/user/auth/password-reset-ui.spec.ts
+++ b/packages/test-suite/tests/user/auth/password-reset-ui.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from '@playwright/test';
+import { createPasswordResetToken } from '@DarkAuth/api/src/models/passwordResetTokens.ts';
+import { setSetting } from '@DarkAuth/api/src/services/settings.ts';
+import { FIXED_TEST_ADMIN, createTestUser } from '../../../fixtures/testData.js';
+import { createUserViaAdmin } from '../../../setup/helpers/auth.js';
+import { installDarkAuth } from '../../../setup/install.js';
+import { createTestServers, destroyTestServers, type TestServers } from '../../../setup/server.js';
+
+async function configurePasswordReset(servers: TestServers, enabled: boolean, showLink = true) {
+  const context = servers.getContext();
+  await setSetting(context, 'email.transport', 'smtp');
+  await setSetting(context, 'email.from', 'DarkAuth <noreply@example.com>');
+  await setSetting(context, 'email.smtp.host', 'localhost');
+  await setSetting(context, 'email.smtp.port', 2525);
+  await setSetting(context, 'email.smtp.user', 'test');
+  await setSetting(context, 'email.smtp.password', 'test', true);
+  await setSetting(context, 'email.smtp.enabled', true);
+  await setSetting(context, 'users.password_reset_email_enabled', enabled);
+  await setSetting(context, 'users.password_reset_show_login_link', showLink);
+}
+
+test.describe('User - Password reset UI', () => {
+  let servers: TestServers;
+
+  test.beforeAll(async () => {
+    servers = await createTestServers({ testName: 'user-password-reset-ui' });
+    await installDarkAuth({
+      adminUrl: servers.adminUrl,
+      adminEmail: FIXED_TEST_ADMIN.email,
+      adminName: FIXED_TEST_ADMIN.name,
+      adminPassword: FIXED_TEST_ADMIN.password,
+      installToken: 'test-install-token',
+    });
+  });
+
+  test.afterAll(async () => {
+    if (servers) await destroyTestServers(servers);
+  });
+
+  test('login link follows password reset visibility settings', async ({ page }) => {
+    await configurePasswordReset(servers, true, true);
+    await page.goto(`${servers.userUrl}/login`);
+    await expect(page.getByRole('link', { name: 'Forgot your password?' })).toBeVisible();
+
+    await page.getByRole('link', { name: 'Forgot your password?' }).click();
+    await expect(page).toHaveURL(/\/forgot-password$/);
+    await expect(page.getByRole('heading', { name: 'Forgot your password?' })).toBeVisible();
+
+    await configurePasswordReset(servers, true, false);
+    await page.goto(`${servers.userUrl}/login`);
+    await expect(page.getByRole('link', { name: 'Forgot your password?' })).toHaveCount(0);
+  });
+
+  test('forgot-password page always shows generic submitted copy', async ({ page }) => {
+    await configurePasswordReset(servers, true, true);
+    await page.goto(`${servers.userUrl}/forgot-password`);
+    await page.getByLabel('Email').fill(`missing-${Date.now()}@example.com`);
+    await page.getByRole('button', { name: 'Send reset instructions' }).click();
+    await expect(page.getByText('Check your email')).toBeVisible();
+    await expect(page.getByText('If an account exists, we sent reset instructions.')).toBeVisible();
+  });
+
+  test('reset-password page handles invalid tokens and validates confirmation', async ({ page }) => {
+    await configurePasswordReset(servers, true, true);
+    const user = createTestUser();
+    const { sub } = await createUserViaAdmin(
+      servers,
+      { email: FIXED_TEST_ADMIN.email, password: FIXED_TEST_ADMIN.password },
+      user
+    );
+    const created = await createPasswordResetToken(servers.getContext(), {
+      userSub: sub,
+      email: user.email,
+      ttlMinutes: 30,
+    });
+
+    await page.goto(`${servers.userUrl}/reset-password?token=missing-${Date.now()}`);
+    await expect(page.getByText('This reset link is invalid or expired.')).toBeVisible();
+
+    await page.goto(`${servers.userUrl}/reset-password?token=${encodeURIComponent(created.token)}`);
+    await expect(page.getByText(/Resetting password for/)).toBeVisible();
+    await page.getByLabel('Password', { exact: true }).fill('NewPassword123!');
+    await page.getByLabel('Confirm Password').fill('DifferentPassword123!');
+    await page.getByRole('button', { name: 'Update Password' }).click();
+    await expect(page.getByText('Passwords do not match')).toBeVisible();
+  });
+});

--- a/packages/user-ui/src/App.tsx
+++ b/packages/user-ui/src/App.tsx
@@ -10,6 +10,8 @@ import {
 import Authorize from "./components/Authorize";
 import ChangePasswordView from "./components/ChangePasswordView";
 import Dashboard from "./components/Dashboard";
+import EmailResetPasswordView from "./components/EmailResetPasswordView";
+import ForgotPasswordView from "./components/ForgotPasswordView";
 import LoginView from "./components/LoginView";
 import OtpSetupView from "./components/OtpSetupView";
 import OtpVerifyView from "./components/OtpVerifyView";
@@ -311,6 +313,8 @@ function AppContent() {
           )
         }
       />
+      <Route path="/forgot-password" element={<ForgotPasswordView />} />
+      <Route path="/reset-password" element={<EmailResetPasswordView />} />
       <Route
         path="/signup"
         element={

--- a/packages/user-ui/src/components/AuthViewFrame.tsx
+++ b/packages/user-ui/src/components/AuthViewFrame.tsx
@@ -1,0 +1,34 @@
+import { Link } from "react-router-dom";
+import { useBranding } from "../hooks/useBranding";
+import styles from "./LoginView.module.css";
+import ThemeToggle from "./ThemeToggle";
+
+export default function AuthViewFrame({ children }: { children: React.ReactNode }) {
+  const branding = useBranding();
+  const logoUrl = branding.getLogoUrl();
+  const isDefaultLogo = branding.isDefaultLogoUrl(logoUrl);
+
+  return (
+    <div className={styles.app}>
+      <div className={styles.container}>
+        <div className={styles.authHeader}>
+          <div className={styles.headerTop}>
+            <Link to="/" className={styles.brand}>
+              <span className={styles.brandIcon}>
+                <img
+                  src={logoUrl}
+                  alt={branding.getTitle()}
+                  className={isDefaultLogo ? styles.defaultLogo : ""}
+                />
+              </span>
+              <h1 className={styles.brandTitle}>{branding.getTitle()}</h1>
+            </Link>
+            <ThemeToggle />
+          </div>
+          <p className={styles.tagline}>{branding.getTagline()}</p>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/packages/user-ui/src/components/EmailResetPasswordView.tsx
+++ b/packages/user-ui/src/components/EmailResetPasswordView.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useId, useMemo, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { useBranding } from "../hooks/useBranding";
+import apiService from "../services/api";
+import { sha256Base64Url } from "../services/crypto";
+import opaqueService, { type OpaqueRegistrationState } from "../services/opaque";
+import AuthViewFrame from "./AuthViewFrame";
+import viewStyles from "./LoginView.module.css";
+import styles from "./Register.module.css";
+
+const minimumPasswordLength = 12;
+
+export default function EmailResetPasswordView() {
+  const uid = useId();
+  const branding = useBranding();
+  const [searchParams] = useSearchParams();
+  const token = useMemo(() => searchParams.get("token") || "", [searchParams]);
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [tokenState, setTokenState] = useState<"checking" | "valid" | "invalid">(
+    token ? "checking" : "invalid"
+  );
+  const [maskedEmail, setMaskedEmail] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!token) {
+      setTokenState("invalid");
+      return;
+    }
+    setTokenState("checking");
+    setMaskedEmail(null);
+    setSuccess(false);
+    setError(null);
+    let cancelled = false;
+    apiService
+      .getPasswordResetToken(token)
+      .then((response) => {
+        if (cancelled) return;
+        setTokenState(response.valid ? "valid" : "invalid");
+        setMaskedEmail(response.email || null);
+      })
+      .catch(() => {
+        if (!cancelled) setTokenState("invalid");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (password.length < minimumPasswordLength) {
+      setError(`Password must be at least ${minimumPasswordLength} characters`);
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("Passwords do not match");
+      return;
+    }
+
+    let opaqueState: OpaqueRegistrationState | null = null;
+    let passwordKey: Uint8Array | null = null;
+    let exportKey: Uint8Array | null = null;
+    try {
+      setLoading(true);
+      setError(null);
+      const start = await opaqueService.startRegistration(password, "");
+      opaqueState = start.state;
+      const startResponse = await apiService.passwordResetStart(token, start.request);
+      const finish = await opaqueService.finishRegistration(
+        startResponse.message,
+        startResponse.serverPublicKey,
+        start.state,
+        startResponse.identityU
+      );
+      passwordKey = finish.passwordKey;
+      exportKey = finish.exportKey;
+      const exportKeyHash = await sha256Base64Url(finish.passwordKey);
+      await apiService.passwordResetFinish(token, finish.request, exportKeyHash);
+      setSuccess(true);
+      setPassword("");
+      setConfirmPassword("");
+    } catch (eventError) {
+      setPassword("");
+      setConfirmPassword("");
+      setError(eventError instanceof Error ? eventError.message : "Failed to reset password");
+    } finally {
+      if (opaqueState) opaqueService.clearState(opaqueState);
+      if (passwordKey) passwordKey.fill(0);
+      if (exportKey) exportKey.fill(0);
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AuthViewFrame>
+      <div className={styles.authContainer}>
+        <h2 className={styles.formTitle}>Reset your password</h2>
+        {tokenState === "checking" ? (
+          <div className={viewStyles.infoAlert}>
+            <span className={viewStyles.infoText}>Checking reset link...</span>
+          </div>
+        ) : tokenState === "invalid" ? (
+          <>
+            <div className={styles.errorMessage}>This reset link is invalid or expired.</div>
+            <div className={styles.stageActions}>
+              <Link className={styles.linkButton} to="/forgot-password">
+                Request a new reset link
+              </Link>
+            </div>
+          </>
+        ) : success ? (
+          <>
+            <output className={viewStyles.successAlert} aria-live="polite">
+              <span className={viewStyles.successTitle}>Password updated</span>
+              <span className={viewStyles.successText}>
+                Your password has been reset. Sign in with your new password to continue.
+              </span>
+            </output>
+            <div className={styles.stageActions}>
+              <Link className={styles.linkButton} to="/login">
+                Back to sign in
+              </Link>
+            </div>
+          </>
+        ) : (
+          <form className={styles.form} onSubmit={submit} noValidate>
+            {maskedEmail ? (
+              <div className={viewStyles.infoAlert}>
+                <span className={viewStyles.infoText}>Resetting password for {maskedEmail}</span>
+              </div>
+            ) : null}
+            <div className={styles.formGroup}>
+              <label className={styles.formLabel} htmlFor={`${uid}-password`}>
+                {branding.getText("password", "Password")}
+              </label>
+              <input
+                type="password"
+                id={`${uid}-password`}
+                value={password}
+                onChange={(event) => {
+                  setPassword(event.target.value);
+                  setError(null);
+                }}
+                placeholder={branding.getText(
+                  "createPasswordPlaceholder",
+                  "Create a strong password"
+                )}
+                className={`${styles.formInput} ${error ? styles.error : ""}`}
+                disabled={loading}
+                autoComplete="new-password"
+                required
+              />
+              <div className={styles.helpText}>Must be at least 12 characters</div>
+            </div>
+            <div className={styles.formGroup}>
+              <label className={styles.formLabel} htmlFor={`${uid}-confirmPassword`}>
+                {branding.getText("confirmPassword", "Confirm Password")}
+              </label>
+              <input
+                type="password"
+                id={`${uid}-confirmPassword`}
+                value={confirmPassword}
+                onChange={(event) => {
+                  setConfirmPassword(event.target.value);
+                  setError(null);
+                }}
+                placeholder={branding.getText(
+                  "confirmPasswordPlaceholder",
+                  "Confirm your password"
+                )}
+                className={`${styles.formInput} ${error ? styles.error : ""}`}
+                disabled={loading}
+                autoComplete="new-password"
+                required
+              />
+              {error ? <div className={styles.errorText}>{error}</div> : null}
+            </div>
+            <button type="submit" className={styles.primaryButton} disabled={loading}>
+              {loading ? (
+                <>
+                  <span className={styles.loadingSpinner} />
+                  Updating...
+                </>
+              ) : (
+                "Update Password"
+              )}
+            </button>
+          </form>
+        )}
+        {!success ? (
+          <div className={styles.formFooter}>
+            <p>
+              <Link className={styles.linkButton} to="/login">
+                Back to sign in
+              </Link>
+            </p>
+          </div>
+        ) : null}
+      </div>
+    </AuthViewFrame>
+  );
+}

--- a/packages/user-ui/src/components/ForgotPasswordView.tsx
+++ b/packages/user-ui/src/components/ForgotPasswordView.tsx
@@ -1,0 +1,106 @@
+import { useId, useState } from "react";
+import { Link } from "react-router-dom";
+import { useBranding } from "../hooks/useBranding";
+import apiService from "../services/api";
+import AuthViewFrame from "./AuthViewFrame";
+import viewStyles from "./LoginView.module.css";
+import styles from "./Register.module.css";
+
+const genericMessage = "If an account exists, we sent reset instructions.";
+
+export default function ForgotPasswordView() {
+  const uid = useId();
+  const branding = useBranding();
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [sent, setSent] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!email.trim()) {
+      setError("Email is required");
+      return;
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) {
+      setError("Please enter a valid email address");
+      return;
+    }
+    try {
+      setLoading(true);
+      setError(null);
+      await apiService.requestPasswordReset(email);
+      setSent(true);
+    } catch {
+      setSent(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AuthViewFrame>
+      <div className={styles.authContainer}>
+        <h2 className={styles.formTitle}>
+          {branding.getText("forgotPassword", "Forgot your password?")}
+        </h2>
+        {sent ? (
+          <>
+            <output className={viewStyles.successAlert} aria-live="polite">
+              <span className={viewStyles.successTitle}>Check your email</span>
+              <span className={viewStyles.successText}>{genericMessage}</span>
+            </output>
+            <div className={styles.stageActions}>
+              <Link className={styles.linkButton} to="/login">
+                Back to sign in
+              </Link>
+            </div>
+          </>
+        ) : (
+          <form className={styles.form} onSubmit={submit} noValidate>
+            <div className={styles.formGroup}>
+              <label className={styles.formLabel} htmlFor={`${uid}-email`}>
+                {branding.getText("email", "Email")}
+              </label>
+              <input
+                type="email"
+                id={`${uid}-email`}
+                value={email}
+                onChange={(event) => {
+                  setEmail(event.target.value);
+                  setError(null);
+                }}
+                placeholder={branding.getText("emailPlaceholder", "Enter your email")}
+                className={`${styles.formInput} ${error ? styles.error : ""}`}
+                disabled={loading}
+                autoComplete="email"
+                required
+              />
+              {error ? <div className={styles.errorText}>{error}</div> : null}
+            </div>
+            <button type="submit" className={styles.primaryButton} disabled={loading}>
+              {loading ? (
+                <>
+                  <span className={styles.loadingSpinner} />
+                  Sending...
+                </>
+              ) : (
+                "Send reset instructions"
+              )}
+            </button>
+          </form>
+        )}
+        {!sent ? (
+          <div className={styles.formFooter}>
+            <p>
+              Remember your password?{" "}
+              <Link className={styles.linkButton} to="/login">
+                {branding.getText("signin", "Continue")}
+              </Link>
+            </p>
+          </div>
+        ) : null}
+      </div>
+    </AuthViewFrame>
+  );
+}

--- a/packages/user-ui/src/components/Login.module.css
+++ b/packages/user-ui/src/components/Login.module.css
@@ -132,6 +132,11 @@
   margin-right: 0.5rem;
 }
 
+.inlineAction {
+  margin-top: 1rem;
+  text-align: center;
+}
+
 .formFooter {
   text-align: left;
   margin-top: 1.5rem;

--- a/packages/user-ui/src/components/Login.tsx
+++ b/packages/user-ui/src/components/Login.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { useBranding } from "../hooks/useBranding";
 import apiService from "../services/api";
 import cryptoService, { toBase64Url } from "../services/crypto";
@@ -54,6 +55,11 @@ export default function Login({
   const [resendMessage, setResendMessage] = useState<string | null>(null);
   const [clientCheckLoading, setClientCheckLoading] = useState(!skipClientCheck);
   const [clientCheckError, setClientCheckError] = useState<string | null>(null);
+  const showForgotPasswordLink = !!(
+    window.__APP_CONFIG__?.features?.passwordResetEnabled ||
+    window.__APP_CONFIG__?.features?.passwordResetLoginLinkVisible ||
+    window.__APP_CONFIG__?.features?.passwordResetLoginLinkEnabled
+  );
   const isPreviewMode = useMemo(() => {
     const url = new URL(window.location.href);
     return (
@@ -409,6 +415,13 @@ export default function Login({
               )}
             </Button>
           </div>
+          {showForgotPasswordLink ? (
+            <div className={styles.inlineAction}>
+              <Link className={styles.linkButton} to="/forgot-password">
+                {branding.getText("forgotPassword", "Forgot your password?")}
+              </Link>
+            </div>
+          ) : null}
         </form>
       ) : null}
 

--- a/packages/user-ui/src/hooks/useBranding.ts
+++ b/packages/user-ui/src/hooks/useBranding.ts
@@ -19,7 +19,12 @@ declare global {
   interface Window {
     __APP_CONFIG__?: {
       branding?: BrandingConfig;
-      features?: { selfRegistrationEnabled?: boolean };
+      features?: {
+        selfRegistrationEnabled?: boolean;
+        passwordResetEnabled?: boolean;
+        passwordResetLoginLinkEnabled?: boolean;
+        passwordResetLoginLinkVisible?: boolean;
+      };
     };
   }
 }

--- a/packages/user-ui/src/services/api.ts
+++ b/packages/user-ui/src/services/api.ts
@@ -113,6 +113,22 @@ export interface WrappedDrkResponse {
   wrapped_drk: string;
 }
 
+export interface PasswordResetRequestResponse {
+  success: boolean;
+  message: string;
+}
+
+export interface PasswordResetTokenResponse {
+  valid: boolean;
+  email?: string;
+}
+
+export interface PasswordResetStartResponse {
+  message: string;
+  serverPublicKey: string;
+  identityU: string;
+}
+
 class ApiService {
   private baseUrl: string;
   private onSessionExpired?: () => void;
@@ -446,6 +462,43 @@ class ApiService {
     return this.request("/password/recovery/verify/finish", {
       method: "POST",
       body: JSON.stringify({ finish: finishB64Url, sessionId }),
+    });
+  }
+
+  async requestPasswordReset(email: string): Promise<PasswordResetRequestResponse> {
+    return this.request("/password/reset/request", {
+      method: "POST",
+      body: JSON.stringify({ email }),
+    });
+  }
+
+  async getPasswordResetToken(token: string): Promise<PasswordResetTokenResponse> {
+    const query = new URLSearchParams({ token });
+    return this.request(`/password/reset/token?${query.toString()}`);
+  }
+
+  async passwordResetStart(
+    token: string,
+    requestB64Url: string
+  ): Promise<PasswordResetStartResponse> {
+    return this.request("/password/reset/start", {
+      method: "POST",
+      body: JSON.stringify({ token, request: requestB64Url }),
+    });
+  }
+
+  async passwordResetFinish(
+    token: string,
+    recordB64Url: string,
+    exportKeyHashB64Url: string
+  ): Promise<{ success: boolean }> {
+    return this.request("/password/reset/finish", {
+      method: "POST",
+      body: JSON.stringify({
+        token,
+        record: recordB64Url,
+        export_key_hash: exportKeyHashB64Url,
+      }),
     });
   }
 

--- a/specs/0_SECURITY_WHITEPAPER.md
+++ b/specs/0_SECURITY_WHITEPAPER.md
@@ -188,6 +188,7 @@ User/OIDC (port 9080)
 - `POST /api/token` (form): authorization_code; returns `zk_drk_hash` when applicable
 - `POST /opaque/login/start`, `POST /opaque/login/finish`
 - `POST /opaque/register/start`, `POST /opaque/register/finish`
+- `POST /password/reset/request`, `GET /password/reset/token`, `POST /password/reset/start`, `POST /password/reset/finish`
 - `POST /password/change/verify/start`, `POST /password/change/verify/finish`
 - `POST /password/change/start`, `POST /password/change/finish`
 - `GET /crypto/wrapped-drk`, `PUT /crypto/wrapped-drk`
@@ -210,6 +211,10 @@ Constraints
 
 Password secrecy (OPAQUE)
 - Passwords are not sent to the server in the OPAQUE flow; verifiers do not allow offline recovery by themselves. Login finish binds the authenticated account to server‑tracked identity; enumeration resistance and rate limits are applied.
+
+Email reset safety
+- Self-service email reset is SMTP-gated and returns generic request responses to avoid account enumeration. Reset tokens are high-entropy, single-use, short-lived, and stored only as keyed hashes. Successful reset replaces the OPAQUE record and revokes active sessions and pending grants.
+- Email reset restores account access, not encrypted data. If DRK-wrapped material was derived from the previous password export key, users must use old-password recovery or generate new keys after signing in with the new password.
 
 DRK secrecy
 - Only wrapped DRK is stored. Without KW (derived from export_key on the device), the server cannot decrypt DRK from stored state during honest frontend operation.

--- a/specs/PASSWORD_RESET.md
+++ b/specs/PASSWORD_RESET.md
@@ -1,0 +1,502 @@
+# Password Reset by Email
+
+## Goal
+
+Add a secure self-service forgotten-password flow for user accounts:
+- Login page shows a `Forgot your password?` link when enabled.
+- User requests a reset email without account enumeration.
+- Email uses the editable admin email template system.
+- Reset link lets the user set a new OPAQUE password without knowing the old password.
+- Existing sessions and refresh tokens are revoked after a successful reset.
+- The feature is controlled by admin settings and only works when outbound email is available.
+
+This feature is account access recovery, not cryptographic data recovery. If a user no longer knows the old password, DarkAuth cannot decrypt old DRK-wrapped material from that old password. The reset flow must preserve this zero-knowledge boundary and route the user through key recovery or key regeneration after login.
+
+## Current State
+
+- SMTP settings and templated email sending already exist.
+- Admin email templates already include `password_recovery`, but no backend flow sends it.
+- User UI has no public forgot-password page or reset-token page.
+- Existing `/password/recovery/verify/*` endpoints are old-password key recovery endpoints for DRK continuity after password changes. They are not email reset endpoints.
+- Admins can mark users/admins as requiring password reset, and admins can set temporary passwords. This is separate from self-service email reset.
+
+## Product Decisions
+
+- Feature default: disabled unless explicitly enabled by an admin or install-time default.
+- Enabling requires SMTP to be complete and `email.smtp.enabled = true`.
+- User request response is always generic: `If an account exists, we sent reset instructions.`
+- Reset links are single-use, short-lived, and store only hashed tokens.
+- Reset does not automatically sign the user in. The user returns to login after success.
+- OTP/MFA remains required on next login.
+- Email verification remains separate. If email verification is enabled and the account email is unverified, the request endpoint still returns the generic response and should not send reset mail unless product explicitly chooses otherwise.
+- Existing active sessions, refresh tokens, authorization codes, and pending OIDC auth requests for the user are invalidated after successful reset.
+- Admin users are out of scope for the first implementation unless explicitly added later. If supported later, use a separate admin reset flow and table cohort, not the user login page.
+
+## Scope
+
+### In Scope
+
+- DB migration for password reset tokens.
+- Settings for enablement, token TTL, request throttling, and optional login-page visibility.
+- Public API to request a reset email.
+- Public API to start and finish OPAQUE reset registration with a reset token.
+- User UI routes for request and reset-token forms.
+- Login page link and branding wording support.
+- Admin Settings controls.
+- Admin Email Templates page support for reset email variables.
+- Session/token invalidation after reset.
+- Audit logging.
+- API, model, and UI tests.
+
+### Out of Scope
+
+- Recovering encrypted data without the previous password.
+- Automatically emailing temporary passwords.
+- Allowing admins to view reset tokens.
+- Resetting admin-user passwords from the user login page.
+- Passwordless login or magic-link login.
+
+## Data Model
+
+### New table: `password_reset_tokens`
+
+Fields:
+- `id` `uuid` primary key
+- `user_sub` `text` fk -> `users.sub` cascade delete
+- `email` `text` not null
+- `token_hash` `text` unique not null
+- `expires_at` `timestamp` not null
+- `consumed_at` `timestamp null`
+- `created_at` `timestamp` default now
+- `requested_ip_hash` `text null`
+- `user_agent_hash` `text null`
+
+Indexes:
+- Unique index on `token_hash`.
+- Index on `user_sub`.
+- Index on `email`.
+- Index on `expires_at`.
+- Partial or composite index for active-token lookup by `user_sub` and `consumed_at`.
+
+Rules:
+- Store only a token hash, never the plaintext token.
+- Generate token with at least 32 bytes of cryptographically secure random entropy.
+- Hash token with SHA-256 plus an application/server-side pepper if available through existing config/KEK conventions.
+- Only one active reset token per user should be valid. Creating a new token invalidates unconsumed prior tokens for the same user.
+- Token consume must happen in the same transaction as password replacement.
+- Expired/consumed tokens must never reveal which account they belonged to.
+
+## Settings Keys
+
+Add settings rows via default seeding:
+
+### Users / Password Reset
+
+- `users.password_reset_email_enabled` boolean, default `false`
+- `users.password_reset_show_login_link` boolean, default `true`
+- `users.password_reset_token_ttl_minutes` number, default `30`
+- `users.password_reset_request_cooldown_minutes` number, default `5`
+- `users.password_reset_max_requests_per_hour` number, default `3`
+
+Validation:
+- TTL min `5`, max `1440`.
+- Cooldown min `1`, max `60`.
+- Max requests per hour min `1`, max `20`.
+- `users.password_reset_email_enabled` can only be set to `true` when email sending is available.
+
+Behavior:
+- If reset is disabled, public reset endpoints still return safe generic responses where appropriate.
+- Login page link appears only when `users.password_reset_email_enabled = true` and `users.password_reset_show_login_link = true`.
+- Public feature config should expose only whether the link should be shown, not detailed SMTP state.
+
+## Email Template
+
+Reuse the existing `email.templates.password_recovery` key as the password reset email.
+
+Default label:
+- `Password reset`
+
+Default subject:
+- `Reset your password`
+
+Required variables:
+- `name`
+- `reset_link`
+- `expires_minutes`
+
+Optional variables:
+- `email`
+- `requested_at`
+- `ip_hint`
+
+Template behavior:
+- Admin Email Templates page must show the variable list for `password_recovery`.
+- Existing `recovery_link` variable should be migrated or supported as an alias for `reset_link` to avoid breaking customized templates.
+- `signup_existing_account_notice` should point to the forgot-password route only when password reset is enabled. Otherwise it should continue pointing to login.
+
+## Backend Flow
+
+### Request reset email
+
+Endpoint:
+- `POST /api/user/password/reset/request`
+
+Request:
+```json
+{
+  "email": "user@example.com"
+}
+```
+
+Response:
+```json
+{
+  "success": true,
+  "message": "If an account exists, we sent reset instructions."
+}
+```
+
+Rules:
+- Normalize email by trim + lowercase before lookup.
+- Always return the same response for unknown users, disabled feature, unverified account policy, SMTP failures, and success.
+- Rate limit by IP and normalized email.
+- Apply per-account cooldown and hourly cap for existing accounts.
+- Log detailed internal errors, but do not expose them to the client.
+- If a user exists and sending is allowed:
+  - invalidate any active reset tokens for that user
+  - create a fresh token row
+  - send `password_recovery` template with `reset_link`
+  - log audit event
+
+### Validate reset token
+
+Endpoint:
+- `GET /api/user/password/reset/token?token=...`
+
+Response for valid token:
+```json
+{
+  "valid": true,
+  "email": "u***@example.com"
+}
+```
+
+Response for invalid token:
+```json
+{
+  "valid": false
+}
+```
+
+Rules:
+- This endpoint is optional but useful for UI state.
+- It must not return full email, user id, name, or token metadata.
+- It must apply rate limiting.
+
+### Start OPAQUE reset registration
+
+Endpoint:
+- `POST /api/user/password/reset/start`
+
+Request:
+```json
+{
+  "token": "plaintext-reset-token",
+  "request": "base64url-opaque-registration-request"
+}
+```
+
+Response:
+```json
+{
+  "message": "base64url-registration-response",
+  "serverPublicKey": "base64url-server-public-key",
+  "identityU": "user@example.com"
+}
+```
+
+Rules:
+- Validate token hash, expiry, and unconsumed state.
+- Use the token's user email as `identityU`.
+- Do not consume the token in start.
+- Return a generic invalid-token error if token is invalid or expired.
+- Rate limit by IP and token hash.
+
+### Finish OPAQUE reset registration
+
+Endpoint:
+- `POST /api/user/password/reset/finish`
+
+Request:
+```json
+{
+  "token": "plaintext-reset-token",
+  "record": "base64url-opaque-registration-record",
+  "export_key_hash": "base64url-sha256-export-key"
+}
+```
+
+Response:
+```json
+{
+  "success": true
+}
+```
+
+Rules:
+- Validate token hash, expiry, and unconsumed state.
+- Reject password reuse using existing `user_password_history` and `export_key_hash`.
+- Finish OPAQUE registration using the token account email.
+- Replace the user's `opaque_records` row.
+- Insert the new `user_password_history` row.
+- Mark `users.password_reset_required = false`.
+- Mark token `consumed_at = now`.
+- Invalidate all active user sessions and refresh tokens.
+- Delete pending auth codes and pending OIDC auth requests for that user.
+- Invalidate other active reset tokens for the same user.
+- Write audit event.
+- Return success and require normal login.
+
+## Cryptographic Key Recovery Behavior
+
+After email reset, the new password produces a new OPAQUE export key. Existing DRK wrapping may be under the old export key.
+
+Required user experience:
+- On next login/authorization, if wrapped DRK cannot be unwrapped with the new export key, show the existing key recovery panel.
+- User can recover data with old password if remembered.
+- User can generate new keys if old password is unavailable.
+- UI copy must clearly state that generating new keys may make old encrypted content unavailable unless another recovery path exists.
+
+Backend behavior:
+- Do not delete `wrapped_drk`, `wrapped_enc_private_jwk`, encryption public keys, or old opaque history during reset.
+- Preserve enough existing opaque history for the current old-password recovery flow to work.
+- Do not expose previous password verifier data except through the existing authenticated key recovery flow.
+
+## User UI Changes
+
+### Login page
+
+- Add `Forgot your password?` link under the password field or below the submit button.
+- Show only when public config says password reset is enabled and visible.
+- Use branding wording key `forgotPassword`, already present, or add a dedicated `forgotPasswordLink` if needed.
+
+### Forgot password page
+
+Route:
+- `/forgot-password`
+
+Fields:
+- Email
+
+Behavior:
+- Submit calls `POST /api/user/password/reset/request`.
+- Always show generic success copy.
+- Provide link back to login.
+- Disable submit while loading.
+
+### Reset password page
+
+Route:
+- `/reset-password?token=...`
+
+Fields:
+- New password
+- Confirm password
+
+Behavior:
+- Validate minimum password length client-side consistently with existing reset/change forms.
+- Optionally call token validation endpoint for early invalid/expired display.
+- Run OPAQUE registration start/finish with reset token.
+- Show success page with link back to login.
+- Never auto-login.
+- Clear password and OPAQUE state from memory after success/failure.
+
+## Admin UI Changes
+
+### Settings
+
+Add a `Users / Password Reset` or `Email / Password Reset` section with:
+- Enable email password reset
+- Show forgot-password link on login page
+- Token TTL minutes
+- Request cooldown minutes
+- Max requests per hour
+
+Behavior:
+- Disable or block enablement when SMTP settings are incomplete or disabled.
+- Show concise explanatory text that reset restores account access but cannot recover encrypted data without old password.
+- Read-only admins cannot edit.
+
+### Email Templates
+
+Update `password_recovery` template metadata:
+- Label: `Password reset`
+- Description: `Sent when a user requests a password reset.`
+- Variables: `name`, `email`, `reset_link`, `recovery_link`, `expires_minutes`, `requested_at`, `ip_hint`
+
+## Admin-Triggered Reset Interaction
+
+Keep existing admin flows:
+- Mark user as requiring reset.
+- Set temporary password.
+
+Optional enhancement:
+- Add `Send password reset email` action to user row/detail page.
+- This action should call the same token creation service as the public request endpoint.
+- It must require write admin role.
+- It should show success/failure to the admin and audit `ADMIN_USER_PASSWORD_RESET_EMAIL_SENT`.
+- It should still not reveal or display the reset token.
+
+## API and Service Structure
+
+Suggested backend modules:
+- `models/passwordResetTokens.ts`
+- `services/passwordReset.ts`
+- `controllers/user/passwordResetRequest.ts`
+- `controllers/user/passwordResetToken.ts`
+- `controllers/user/passwordResetStart.ts`
+- `controllers/user/passwordResetFinish.ts`
+
+Shared service responsibilities:
+- normalize email
+- check settings and email availability
+- enforce cooldown/caps
+- create/hash tokens
+- render/send email template
+- validate/consume token
+- complete OPAQUE reset transaction
+- invalidate sessions and grants
+- audit events
+
+Avoid duplicating OPAQUE registration logic. Reuse the existing password set/change model patterns where possible, but keep the no-current-password reset authorization tied strictly to the reset token.
+
+## Security Requirements
+
+- No account enumeration from request, validation, resend, disabled feature, or SMTP error paths.
+- Tokens must be high entropy, one-time, short-lived, and hashed at rest.
+- Token value must appear only in the email link and request body.
+- Never log plaintext tokens.
+- Rate limit:
+  - request endpoint by IP
+  - request endpoint by normalized email
+  - token validation/start/finish by IP and token hash
+- Invalidate older reset tokens whenever a new token is issued.
+- Invalidate sessions and refresh tokens after successful reset.
+- Require CSRF protection for same-origin POSTs where the existing user router expects it, but avoid requiring an existing login session.
+- Do not accept client-supplied email/user id during reset start/finish.
+- Do not weaken OPAQUE identity binding. `identityU` must come from server-side token lookup.
+- Preserve MFA requirements after reset.
+- Keep timing and response differences small enough to avoid obvious enumeration.
+- Audit successful sends, successful resets, invalid-token attempts above threshold, rate-limited attempts, and SMTP failures.
+
+## Audit Events
+
+Add or reuse event names:
+- `USER_PASSWORD_RESET_REQUESTED`
+- `USER_PASSWORD_RESET_EMAIL_SENT`
+- `USER_PASSWORD_RESET_EMAIL_SKIPPED`
+- `USER_PASSWORD_RESET_TOKEN_INVALID`
+- `USER_PASSWORD_RESET_COMPLETED`
+- `USER_PASSWORD_RESET_RATE_LIMITED`
+- `ADMIN_USER_PASSWORD_RESET_EMAIL_SENT` optional
+
+Audit payloads should not include plaintext tokens or full sensitive request metadata.
+
+## Error Handling
+
+User-facing messages:
+- Request submitted: `If an account exists, we sent reset instructions.`
+- Invalid token: `This password reset link is invalid or expired.`
+- Reused password: `Choose a password you have not used before.`
+- SMTP disabled on direct reset page/request path: use generic request response; admin settings can show precise SMTP errors.
+- Reset success: `Your password has been reset. Sign in with your new password.`
+
+Internal errors:
+- SMTP send failures should be logged and audited.
+- Token creation failures should return generic request response when possible.
+- OPAQUE finish failures should return a validation error without consuming the token unless the token itself is invalid.
+
+## Testing Plan
+
+### Model and service tests
+
+- Token generation stores only hash.
+- Token validation accepts active token and rejects consumed/expired/unknown tokens.
+- Creating a new token invalidates previous active tokens for the same user.
+- Request cooldown and hourly cap work per user/email.
+- Unknown email request returns generic success and sends no email.
+- Disabled feature returns generic success and sends no email.
+- SMTP unavailable path returns generic success and logs/audits internally.
+- Finish consumes token and updates OPAQUE record atomically.
+- Reused password hash is rejected.
+- Consumed token cannot be reused.
+- Sessions and refresh tokens are invalidated after reset.
+
+### API tests
+
+- `POST /password/reset/request` generic response for existing and unknown emails.
+- Request endpoint sends `password_recovery` template with correct variables.
+- `GET /password/reset/token` valid/invalid responses do not expose account data.
+- `POST /password/reset/start` binds `identityU` to token account email.
+- `POST /password/reset/finish` resets password and requires normal login after success.
+- Old password fails login after reset.
+- New password succeeds login after reset.
+- OTP requirement remains enforced after reset.
+- Email verification policy for unverified accounts follows product decision.
+- Rate limits return appropriate status without revealing account existence.
+
+### UI tests
+
+- Login link appears when enabled and hidden when disabled.
+- Forgot-password page shows generic success for submitted email.
+- Reset page handles missing, invalid, expired, and valid token states.
+- Reset page validates password confirmation.
+- Successful reset redirects or links back to login.
+- Admin Settings validates SMTP dependency before enabling reset.
+- Email Templates page exposes reset variables and saves customized template.
+- Key recovery panel appears after reset when existing wrapped DRK cannot be unwrapped with the new password.
+
+### End-to-end tests
+
+- Configure SMTP test transport or mock sender.
+- Register user.
+- Request password reset.
+- Extract reset link from captured email.
+- Set new password.
+- Confirm old password no longer works.
+- Confirm new password works.
+- Confirm all pre-reset sessions are invalid.
+- Confirm encrypted-data recovery path appears and old-password recovery still works if the old password is supplied.
+
+## Rollout Notes
+
+- Ship DB migration before enabling the setting.
+- Keep `users.password_reset_email_enabled = false` by default for existing installs.
+- Existing customized `password_recovery` templates may use `recovery_link`; support aliasing during rollout.
+- Update documentation to clarify the distinction between password reset and encrypted data recovery.
+- Consider adding a one-time admin notice after deploy that SMTP must be configured before email reset can be enabled.
+
+## Implementation Checklist
+
+- [x] Add `password_reset_tokens` table and indexes
+- [x] Add settings defaults and validation
+- [x] Expose safe public feature flag for login link visibility
+- [x] Add password reset token model
+- [x] Add password reset service
+- [x] Add request endpoint
+- [x] Add optional token validation endpoint
+- [x] Add OPAQUE reset start endpoint
+- [x] Add OPAQUE reset finish endpoint
+- [x] Add session/refresh-token/grant invalidation after reset
+- [x] Wire `password_recovery` template sending with `reset_link`
+- [x] Update Email Templates metadata and alias `recovery_link`
+- [x] Add admin settings controls
+- [x] Add login page forgot-password link
+- [x] Add forgot-password page
+- [x] Add reset-password token page
+- [x] Add optional admin `Send password reset email` action
+- [x] Add audit events
+- [x] Add model/service/API tests
+- [x] Add UI and end-to-end tests
+- [x] Run `npm run tidy`
+- [x] Run `npm run build`


### PR DESCRIPTION
## Summary
- add configurable email password reset settings, secure reset tokens, rate limiting, email template support, and admin-triggered reset emails
- add user forgotten-password and reset screens plus admin settings, template metadata, and user action controls
- document the feature across repo docs, brochureware docs, the security whitepaper, and the implementation spec checklist

## Verification
- `npm run tidy`
- `npm run build`
- `node --env-file-if-exists=../../.env --test packages/api/src/models/passwordResetTokens.test.ts packages/api/src/services/passwordReset.test.ts packages/api/src/services/emailTemplates.test.ts`
- `npx playwright test tests/api/password-reset.spec.ts tests/user/auth/password-reset-ui.spec.ts --workers=1`
