### PR TITLE
fix(api): persist opaque login state

### DIFF
--- a/packages/admin-ui/src/pages/Settings.tsx
+++ b/packages/admin-ui/src/pages/Settings.tsx
@@ -313,13 +313,6 @@ export default function Settings() {
                 {inner.map(([sub, items]) => (
                   <div key={sub}>
                     {sub !== "General" && <div className={settingsStyles.subHeading}>{sub}</div>}
-                    {items.some((item) => item.key.startsWith("users.password_reset_")) ? (
-                      <SettingRow
-                        label="Password reset by email"
-                        description="Reset emails restore account access only. Encrypted data still requires old-password recovery or key regeneration after sign-in."
-                        right={null}
-                      />
-                    ) : null}
                     <div className={settingsStyles.rows}>
                       {items
                         .slice()

--- a/packages/api/src/lib/opaque/opaque-ts-wrapper.test.ts
+++ b/packages/api/src/lib/opaque/opaque-ts-wrapper.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createOpaqueClientService, createOpaqueServerService } from "./opaque-ts-wrapper.ts";
+
+describe("opaque-ts wrapper", () => {
+  it("finishes login on a different server instance using persisted state", async () => {
+    const identityU = "user@example.com";
+    const identityS = "DarkAuth";
+    const password = "correct horse battery staple";
+    const serverA = await createOpaqueServerService();
+    const serverB = await createOpaqueServerService(serverA.getState());
+    const registerClient = await createOpaqueClientService();
+    const registrationStart = await registerClient.startRegistration(password, identityU);
+    const registrationResponse = await serverA.startRegistration(
+      registrationStart.request,
+      identityU,
+      identityS
+    );
+    const registrationFinish = await registerClient.finishRegistration(
+      registrationResponse.response,
+      registrationStart.state,
+      serverA.getSetup().serverPublicKey,
+      identityS,
+      identityU
+    );
+    const record = await serverA.finishRegistration(
+      registrationFinish.upload,
+      identityU,
+      identityS
+    );
+    const loginClient = await createOpaqueClientService();
+    const loginStart = await loginClient.startLogin(password, identityU);
+    const loginResponse = await serverA.startLogin(
+      loginStart.request,
+      record.envelope,
+      record.serverPublicKey,
+      identityU,
+      identityS
+    );
+    const loginFinish = await loginClient.finishLogin(
+      loginResponse.response,
+      loginStart.state,
+      serverA.getSetup().serverPublicKey,
+      identityS,
+      identityU
+    );
+    const result = await serverB.finishLogin(
+      loginFinish.finish,
+      loginResponse.state,
+      identityU,
+      identityS
+    );
+
+    assert.equal(result.sessionKey.length, loginFinish.session_key.length);
+    assert.deepEqual(Array.from(result.sessionKey), Array.from(loginFinish.session_key));
+  });
+});

--- a/packages/api/src/lib/opaque/opaque-ts-wrapper.ts
+++ b/packages/api/src/lib/opaque/opaque-ts-wrapper.ts
@@ -70,13 +70,11 @@ export class OpaqueServer {
   oprfSeed: number[];
   serverKeypair: AKEExportKeyPair | null = null;
   serverIdentity: string;
-  activeSessions: Map<string, CloudflareOpaqueServer>;
   secureLogger: ReturnType<typeof createSecureLogger>;
 
   constructor() {
     this.config = new OpaqueConfig(OpaqueID.OPAQUE_P256);
     this.serverIdentity = "DarkAuth";
-    this.activeSessions = new Map();
     this.oprfSeed = [];
     this.secureLogger = createSecureLogger();
   }
@@ -294,7 +292,6 @@ export class OpaqueServer {
     if (!this.server) {
       throw new Error("Server not initialized. Call initialize() first.");
     }
-    // Create a per-session server instance to avoid concurrency issues
     if (!this.serverKeypair) {
       throw new Error("Server not initialized. Call initialize() first.");
     }
@@ -309,9 +306,12 @@ export class OpaqueServer {
       throw new Error(`Auth init failed: ${ke2.message}`);
     }
 
-    // Generate our own opaque session id and keep mapping
+    const authState = perServer.exportAuthState();
+    if (authState instanceof Error) {
+      throw new Error(`Auth state export failed: ${authState.message}`);
+    }
     const sid = toBase64Url(randomBytes(16));
-    this.activeSessions.set(sid, perServer);
+    const state = Uint8Array.from(authState);
 
     this.secureLogger.logOpaqueOperation("login_start", {
       identityU,
@@ -319,13 +319,11 @@ export class OpaqueServer {
       success: true,
     });
 
-    this.secureLogger.logSessionEvent("created", sid, {
-      count: this.activeSessions.size,
-    });
+    this.secureLogger.logSessionEvent("created", sid);
 
     return {
       response: new Uint8Array(ke2.serialize()),
-      state: new Uint8Array(Buffer.from(sid)),
+      state,
     };
   }
 
@@ -360,14 +358,23 @@ export class OpaqueServer {
       );
     }
 
-    const sid = Buffer.from(_serverState || []).toString();
-    this.secureLogger.logDebugInfo("Looking up session", {
-      hasSession: this.activeSessions.has(sid),
-    });
+    if (!_serverState || _serverState.length === 0) {
+      this.secureLogger.logSecureError("Session state not found");
+      throw new Error("Invalid or expired login session");
+    }
 
-    const perServer = this.activeSessions.get(sid);
-    if (!perServer) {
-      this.secureLogger.logSecureError("Session not found");
+    if (!this.serverKeypair) {
+      throw new Error("Server not initialized. Call initialize() first.");
+    }
+    const perServer = new CloudflareOpaqueServer(
+      this.config,
+      this.oprfSeed,
+      this.serverKeypair,
+      this.serverIdentity
+    );
+    const importResult = perServer.importAuthState(Array.from(_serverState));
+    if (importResult instanceof Error) {
+      this.secureLogger.logSecureError("Session state restore failed");
       throw new Error("Invalid or expired login session");
     }
 
@@ -377,7 +384,6 @@ export class OpaqueServer {
     if (result instanceof Error) {
       this.secureLogger.logOpaqueOperation("login_finish", {
         identityU: _identityU,
-        sessionId: sid,
         success: false,
         error: result.message,
       });
@@ -386,18 +392,14 @@ export class OpaqueServer {
 
     this.secureLogger.logOpaqueOperation("login_finish", {
       identityU: _identityU,
-      sessionId: sid,
       success: true,
     });
 
-    this.secureLogger.logSessionEvent("deleted", sid, {
-      count: this.activeSessions.size - 1,
-    });
+    this.secureLogger.logSessionEvent("deleted", "session");
 
     const out = {
       sessionKey: new Uint8Array(result.session_key),
     };
-    this.activeSessions.delete(sid);
     return out;
   }
 }

--- a/packages/api/src/services/opaque.test.ts
+++ b/packages/api/src/services/opaque.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { eq } from "drizzle-orm";
+import { createPglite } from "../db/pglite.ts";
+import { opaqueLoginSessions } from "../db/schema.ts";
+import { createOpaqueClientService } from "../lib/opaque/opaque-ts-wrapper.ts";
+import type { Context } from "../types.ts";
+import { createOpaqueService } from "./opaque.ts";
+
+function createLogger() {
+  return {
+    error() {},
+    warn() {},
+    info() {},
+    debug() {},
+    trace() {},
+    fatal() {},
+  };
+}
+
+function createContext(db: Context["db"]): Context {
+  return {
+    db,
+    config: {
+      publicOrigin: "http://localhost:9080",
+      issuer: "http://localhost:9080",
+      kekPassphrase: "",
+      inInstallMode: false,
+    },
+    logger: createLogger(),
+    services: {},
+    cleanupFunctions: [],
+    destroy: async () => {},
+  } as Context;
+}
+
+test("OPAQUE login finish works on a different service instance using database state", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "darkauth-opaque-service-test-"));
+  const { db, close } = await createPglite(directory);
+  const contextA = createContext(db);
+  const contextB = createContext(db);
+
+  try {
+    const identityU = "user@example.com";
+    const identityS = "DarkAuth";
+    const password = "correct horse battery staple";
+    const opaqueA = await createOpaqueService(contextA);
+    const opaqueB = await createOpaqueService(contextB);
+    const registerClient = await createOpaqueClientService();
+    const registrationStart = await registerClient.startRegistration(password, identityU);
+    const registrationResponse = await opaqueA.startRegistration(
+      registrationStart.request,
+      identityU,
+      identityS
+    );
+    const registrationFinish = await registerClient.finishRegistration(
+      registrationResponse.message,
+      registrationStart.state,
+      registrationResponse.serverPublicKey,
+      identityS,
+      identityU
+    );
+    const record = await opaqueA.finishRegistration(
+      registrationFinish.upload,
+      identityU,
+      identityS
+    );
+    const loginClient = await createOpaqueClientService();
+    const loginStart = await loginClient.startLogin(password, identityU);
+    const loginResponse = await opaqueA.startLogin(
+      loginStart.request,
+      record,
+      identityU,
+      identityS
+    );
+    const loginFinish = await loginClient.finishLogin(
+      loginResponse.message,
+      loginStart.state,
+      registrationResponse.serverPublicKey,
+      identityS,
+      identityU
+    );
+    const result = await opaqueB.finishLogin(loginFinish.finish, loginResponse.sessionId);
+    const remaining = await db.query.opaqueLoginSessions.findFirst({
+      where: eq(opaqueLoginSessions.id, loginResponse.sessionId),
+    });
+
+    assert.deepEqual(Array.from(result.sessionKey), Array.from(loginFinish.session_key));
+    assert.equal(remaining, undefined);
+  } finally {
+    await close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/packages/api/src/services/opaque.ts
+++ b/packages/api/src/services/opaque.ts
@@ -141,7 +141,7 @@ export async function createOpaqueService(context?: Context) {
         context?.logger?.debug({ event: "opaque.startLogin", respLen: result.response.length });
       } catch {}
 
-      const sessionId = Buffer.from(result.state).toString();
+      const sessionId = toBase64Url(randomBytes(16));
       const expiresAt = new Date(Date.now() + 10 * 60 * 1000);
 
       if (!context) {

--- a/packages/opaque-ts/src/3dh_server.ts
+++ b/packages/opaque-ts/src/3dh_server.ts
@@ -61,6 +61,18 @@ export class AKE3DHServer {
         return auth_response
     }
 
+    exportState(): number[] | Error {
+        if (!this.expected) {
+            return new Error('handshake error')
+        }
+        return this.expected.serialize()
+    }
+
+    importState(bytes: number[]): Error | void {
+        const expected = ExpectedAuthResult.deserialize(this.config, bytes)
+        this.expected = expected
+    }
+
     finish(auth_finish: AuthFinish): { session_key: number[] } | Error {
         if (!this.expected) {
             return new Error('handshake error')

--- a/packages/opaque-ts/src/opaque_server.ts
+++ b/packages/opaque-ts/src/opaque_server.ts
@@ -110,6 +110,14 @@ export class OpaqueServer implements RegistrationServer, AuthServer {
         return ke2
     }
 
+    exportAuthState(): number[] | Error {
+        return this.ake.exportState()
+    }
+
+    importAuthState(bytes: number[]): Error | void {
+        return this.ake.importState(bytes)
+    }
+
     authFinish(ke3: KE3): { session_key: number[] } | Error {
         return this.ake.finish(ke3.auth_finish)
     }


### PR DESCRIPTION
## Summary
- persist serializable OPAQUE login state so login finish can run on any replica
- remove the pod-local OPAQUE active session map dependency while keeping login sessions in the database
- add wrapper and database-backed service regression coverage for cross-instance OPAQUE login
- remove the password reset settings explanatory note from the admin settings page

## Verification
- `node --env-file-if-exists=../../.env --test src/lib/opaque/opaque-ts-wrapper.test.ts src/services/opaque.test.ts`
- `npm run tidy`
- `npm run build`
