### PR TITLE
refactor(admin-ui): reorganize admin sidebar navigation

### DIFF
--- a/packages/admin-ui/src/components/app-sidebar.module.css
+++ b/packages/admin-ui/src/components/app-sidebar.module.css
@@ -39,7 +39,6 @@
   object-fit: contain;
 }
 
-/* Apply brightness filter to logo in dark mode */
 :global(.dark) .logoIcon {
   filter: brightness(100);
 }
@@ -56,9 +55,21 @@
 }
 
 .brandSubtitle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   font-size: 12px;
   color: hsl(var(--muted-foreground));
   margin: 0;
+}
+
+.versionBadge {
+  border: 1px solid hsl(var(--border));
+  border-radius: 6px;
+  color: hsl(var(--foreground));
+  font-size: 11px;
+  line-height: 1;
+  padding: 3px 5px;
 }
 
 .navigation {
@@ -80,7 +91,7 @@
   font-weight: 600;
   color: hsl(var(--muted-foreground));
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0;
   margin-bottom: 8px;
   padding: 0 12px;
 }

--- a/packages/admin-ui/src/components/app-sidebar.tsx
+++ b/packages/admin-ui/src/components/app-sidebar.tsx
@@ -19,27 +19,29 @@ import SidebarNavGroup, { type SidebarNavItem } from "@/components/navigation/si
 import { getTheme, setTheme } from "@/lib/theme";
 import styles from "./app-sidebar.module.css";
 
-const mainItems: SidebarNavItem[] = [
-  { title: "Dashboard", url: "/", icon: Home },
+const mainItems: SidebarNavItem[] = [{ title: "Dashboard", url: "/", icon: Home }];
+
+const identityItems: SidebarNavItem[] = [
   { title: "Users", url: "/users", icon: Users },
   { title: "Organizations", url: "/organizations", icon: Shield },
   { title: "Roles", url: "/roles", icon: KeyRound },
-  { title: "Clients", url: "/clients", icon: Lock },
-  { title: "Branding", url: "/branding", icon: Monitor },
-];
-
-const securityItems: SidebarNavItem[] = [
   { title: "Permissions", url: "/permissions", icon: KeyRound },
-  { title: "Keys", url: "/keys", icon: Key },
-  { title: "Audit Logs", url: "/audit", icon: Lock },
 ];
 
-const systemItems: SidebarNavItem[] = [
-  { title: "Changelog", url: "/changelog", icon: FileText },
-  { title: "Settings", url: "/settings", icon: Settings },
-  { title: "Email", url: "/settings/email-templates", icon: FileText },
-  { title: "Admin Users", url: "/settings/admin-users", icon: Users },
+const oauthItems: SidebarNavItem[] = [
+  { title: "Clients", url: "/clients", icon: Lock },
+  { title: "Signing Keys", url: "/keys", icon: Key },
 ];
+
+const settingsItems: SidebarNavItem[] = [
+  { title: "Admin Users", url: "/settings/admin-users", icon: Users },
+  { title: "Audit Logs", url: "/audit", icon: Lock },
+  { title: "Branding", url: "/branding", icon: Monitor },
+  { title: "Email Templates", url: "/settings/email-templates", icon: FileText },
+  { title: "Settings", url: "/settings", icon: Settings },
+];
+
+const currentAppVersion = (import.meta.env.VITE_APP_VERSION || "").trim();
 
 interface AdminSessionData {
   adminId: string;
@@ -96,7 +98,12 @@ export function AppSidebar({ onClose, adminSession, onLogout }: AppSidebarProps)
             </div>
             <h2>DarkAuth</h2>
           </div>
-          <p className={styles.brandSubtitle}>Admin Portal</p>
+          <p className={styles.brandSubtitle}>
+            {currentAppVersion ? (
+              <span className={styles.versionBadge}>v{currentAppVersion.replace(/^v/i, "")}</span>
+            ) : null}
+            <span>Admin Portal</span>
+          </p>
         </div>
       </div>
 
@@ -108,14 +115,20 @@ export function AppSidebar({ onClose, adminSession, onLogout }: AppSidebarProps)
           onNavigate={handleNavClick}
         />
         <SidebarNavGroup
-          label="Security"
-          items={securityItems}
+          label="Identity"
+          items={identityItems}
           isActive={isActive}
           onNavigate={handleNavClick}
         />
         <SidebarNavGroup
-          label="System"
-          items={systemItems}
+          label="OAuth"
+          items={oauthItems}
+          isActive={isActive}
+          onNavigate={handleNavClick}
+        />
+        <SidebarNavGroup
+          label="Settings"
+          items={settingsItems}
           isActive={(path) =>
             path === "/settings" ? location.pathname === "/settings" : isActive(path)
           }

--- a/packages/admin-ui/src/pages/Dashboard.tsx
+++ b/packages/admin-ui/src/pages/Dashboard.tsx
@@ -248,7 +248,7 @@ export default function Dashboard() {
           description="Using ZK delivery"
         />
         <StatsCard
-          title="Active Keys"
+          title="Active Signing Keys"
           icon={<KeyRound size={16} />}
           value={activeSigningKeys}
           description="Current signing keys"
@@ -467,7 +467,7 @@ export default function Dashboard() {
                   }}
                 >
                   {" "}
-                  <KeyRound size={16} /> Manage Keys
+                  <KeyRound size={16} /> Manage Signing Keys
                 </Button>
               </div>
             </CardContent>

--- a/packages/admin-ui/src/pages/Keys.tsx
+++ b/packages/admin-ui/src/pages/Keys.tsx
@@ -107,24 +107,24 @@ export default function Keys() {
   return (
     <div>
       <PageHeader
-        title="Cryptographic Keys"
-        subtitle="Manage signing and encryption keys"
+        title="Signing Keys"
+        subtitle="Manage token signing keys"
         actions={
           <Button variant="outline" onClick={rotate} disabled={rotating}>
             <RefreshCw />
-            Rotate Keys
+            Rotate Signing Keys
           </Button>
         }
       />
       <StatsGrid>
         <StatsCard
-          title="Total Keys"
+          title="Total Signing Keys"
           icon={<Key size={16} />}
           value={allKeys.length}
           description="JWKS entries"
         />
         <StatsCard
-          title="Active Keys"
+          title="Active Signing Keys"
           icon={<Shield size={16} />}
           value={activeKeys.length}
           description={`Active kid: ${activeKid}`}
@@ -132,10 +132,10 @@ export default function Keys() {
       </StatsGrid>
 
       <ListCard
-        title="Key Management"
-        description="View and manage cryptographic keys used for signing and encryption"
+        title="Signing Key Management"
+        description="View and manage JWKS entries used for token signing"
         search={{
-          placeholder: "Search keys...",
+          placeholder: "Search signing keys...",
           value: searchQuery,
           onChange: (value) => {
             setCurrentPage(1);
@@ -143,7 +143,7 @@ export default function Keys() {
           },
         }}
         rightActions={
-          <Button variant="outline" size="icon" aria-label="Search keys">
+          <Button variant="outline" size="icon" aria-label="Search signing keys">
             <Search size={16} />
           </Button>
         }

--- a/packages/test-suite/tests/admin/navigation/sidebar.spec.ts
+++ b/packages/test-suite/tests/admin/navigation/sidebar.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test';
+import { FIXED_TEST_ADMIN } from '../../../fixtures/testData.js';
+import { installDarkAuth } from '../../../setup/install.js';
+import { ensureAdminDashboard } from '../../../setup/helpers/admin.js';
+import { createTestServers, destroyTestServers, type TestServers } from '../../../setup/server.js';
+
+test.describe('Admin - Sidebar Navigation', () => {
+  let servers: TestServers;
+
+  const adminCred = {
+    email: FIXED_TEST_ADMIN.email,
+    password: FIXED_TEST_ADMIN.password,
+  };
+
+  test.beforeAll(async () => {
+    servers = await createTestServers({ testName: 'admin-sidebar-navigation' });
+    await installDarkAuth({
+      adminUrl: servers.adminUrl,
+      adminEmail: FIXED_TEST_ADMIN.email,
+      adminName: FIXED_TEST_ADMIN.name,
+      adminPassword: FIXED_TEST_ADMIN.password,
+      installToken: 'test-install-token',
+    });
+  });
+
+  test.afterAll(async () => {
+    if (servers) {
+      await destroyTestServers(servers);
+    }
+  });
+
+  test('shows grouped admin navigation with current version', async ({ page }) => {
+    await ensureAdminDashboard(page, servers, adminCred);
+
+    await expect(page.locator('span[class*="versionBadge"]')).toHaveText(/^v\d+\.\d+\.\d+/);
+    await expect(page.getByText('Admin Portal', { exact: true })).toBeVisible();
+
+    const groups = page.locator('div[class*="navGroup"]').filter({ has: page.locator('a') });
+    await expect(groups).toHaveCount(4);
+    await expect(groups.nth(0)).toContainText(/Main[\s\S]*Dashboard/);
+    await expect(groups.nth(1)).toContainText(/Identity[\s\S]*Users[\s\S]*Organizations[\s\S]*Roles[\s\S]*Permissions/);
+    await expect(groups.nth(2)).toContainText(/OAuth[\s\S]*Clients[\s\S]*Signing Keys/);
+    await expect(groups.nth(3)).toContainText(/Settings[\s\S]*Admin Users[\s\S]*Audit Logs[\s\S]*Branding[\s\S]*Email Templates[\s\S]*Settings/);
+
+    await expect(page.getByRole('link', { name: 'Signing Keys' })).toHaveAttribute(
+      'href',
+      '/keys'
+    );
+    await expect(page.getByRole('link', { name: 'Email Templates' })).toHaveAttribute(
+      'href',
+      '/settings/email-templates'
+    );
+    await expect(page.getByRole('link', { name: 'Changelog' })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Reorganizes the admin sidebar into Main, Identity, OAuth, and Settings sections.
- Renames Keys surfaces to Signing Keys and removes Changelog from the sidebar navigation.
- Adds the current app version beside the Admin Portal label in the sidebar header.
- Adds Playwright coverage for the new sidebar structure.

## Verification
- npm run tidy
- npm run build
- PW_REPORTER=dot PW_ARTIFACTS=off npx playwright test tests/admin/navigation/sidebar.spec.ts --reporter=dot --workers=1