### PR TITLE
feat(api,admin-ui): track user last activity

### DIFF
--- a/packages/admin-ui/src/pages/UserEdit.tsx
+++ b/packages/admin-ui/src/pages/UserEdit.tsx
@@ -149,6 +149,14 @@ export default function UserEdit() {
             <FormField label={<Label>Created</Label>}>
               <Input value={new Date(user.createdAt).toLocaleString()} readOnly />
             </FormField>
+            <FormField label={<Label>Last Activity</Label>}>
+              <Input
+                value={
+                  user.lastActivityAt ? new Date(user.lastActivityAt).toLocaleString() : "Never"
+                }
+                readOnly
+              />
+            </FormField>
           </FormGrid>
           <FormActions withMargin>
             {user && (

--- a/packages/admin-ui/src/pages/Users.tsx
+++ b/packages/admin-ui/src/pages/Users.tsx
@@ -195,6 +195,10 @@ export default function Users() {
     });
   };
 
+  const formatOptionalDate = (dateString?: string | null) => {
+    return dateString ? formatDate(dateString) : "Never";
+  };
+
   const openUser = (user: User) => {
     navigate(`/users/${encodeURIComponent(user.sub)}`);
   };
@@ -259,6 +263,12 @@ export default function Users() {
                   />
                   <TableHead>Security</TableHead>
                   <SortableTableHead
+                    label="Last activity"
+                    isActive={sortBy === "lastActivityAt"}
+                    sortOrder={sortOrder}
+                    onToggle={() => toggleSort("lastActivityAt")}
+                  />
+                  <SortableTableHead
                     label="Created"
                     isActive={sortBy === "createdAt"}
                     sortOrder={sortOrder}
@@ -294,6 +304,7 @@ export default function Users() {
                           <span style={{ color: "hsl(var(--muted-foreground))" }}>None</span>
                         )}
                       </TableCell>
+                      <TableCell>{formatOptionalDate(user.lastActivityAt)}</TableCell>
                       <TableCell>{formatDate(user.createdAt)}</TableCell>
                       <TableCell>
                         <RowActions

--- a/packages/admin-ui/src/services/api.ts
+++ b/packages/admin-ui/src/services/api.ts
@@ -74,6 +74,7 @@ export interface User {
   email: string;
   name?: string;
   createdAt: string;
+  lastActivityAt?: string | null;
   passwordResetRequired?: boolean;
   permissions?: string[];
 }

--- a/packages/api/drizzle/0023_user_last_activity.sql
+++ b/packages/api/drizzle/0023_user_last_activity.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "last_activity_at" timestamp;

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1779723134571,
       "tag": "0022_dashboard_auto_login",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1779724800000,
+      "tag": "0023_user_last_activity",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/controllers/admin/listEndpointsSchema.test.ts
+++ b/packages/api/src/controllers/admin/listEndpointsSchema.test.ts
@@ -12,10 +12,10 @@ test("users schema supports standard pagination, search and sorting query fields
     page: 1,
     limit: 20,
     search: "term",
-    sortBy: "email",
+    sortBy: "lastActivityAt",
     sortOrder: "asc",
   });
-  assert.equal(parsed.sortBy, "email");
+  assert.equal(parsed.sortBy, "lastActivityAt");
   assert.equal(parsed.sortOrder, "asc");
 });
 

--- a/packages/api/src/controllers/admin/users.ts
+++ b/packages/api/src/controllers/admin/users.ts
@@ -14,6 +14,7 @@ const UserSchema = z.object({
   email: z.string().email().nullable().optional(),
   name: z.string().nullable().optional(),
   createdAt: z.date().or(z.string()),
+  lastActivityAt: z.date().or(z.string()).nullable().optional(),
   passwordResetRequired: z.boolean().optional(),
   organizationRoles: z
     .array(
@@ -58,7 +59,7 @@ export async function getUsers(
     page: listPageQuerySchema.default(1),
     limit: z.coerce.number().int().positive().max(100).default(20),
     search: listSearchQuerySchema,
-    sortBy: z.enum(["createdAt", "email", "name", "sub"]).optional(),
+    sortBy: z.enum(["createdAt", "email", "name", "sub", "lastActivityAt"]).optional(),
     sortOrder: z.enum(["asc", "desc"]).default("desc"),
   });
   const parsed = Query.parse(Object.fromEntries(url.searchParams));
@@ -76,7 +77,7 @@ export const schema = {
     page: listPageOpenApiQuerySchema,
     limit: z.number().int().positive().optional(),
     search: listSearchQuerySchema,
-    sortBy: z.enum(["createdAt", "email", "name", "sub"]).optional(),
+    sortBy: z.enum(["createdAt", "email", "name", "sub", "lastActivityAt"]).optional(),
     sortOrder: z.enum(["asc", "desc"]).optional(),
   }),
   responses: {

--- a/packages/api/src/controllers/user/token.ts
+++ b/packages/api/src/controllers/user/token.ts
@@ -1,5 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { eq } from "drizzle-orm";
 import { z } from "zod/v4";
+import { users } from "../../db/schema.ts";
 import { InvalidGrantError, InvalidRequestError, UnauthorizedClientError } from "../../errors.ts";
 import { genericErrors } from "../../http/openapi-helpers.ts";
 import { getCachedBody, withRateLimit } from "../../middleware/rateLimit.ts";
@@ -704,7 +706,8 @@ export const postToken = withRateLimit("token")(
         context.logger.info("token zk delivery: drk_hash included");
       }
 
-      if (shouldIssueRefreshTokenForClient(client.grantTypes)) {
+      const issueRefreshToken = shouldIssueRefreshTokenForClient(client.grantTypes);
+      if (issueRefreshToken) {
         const sessionData = {
           sub: user.sub,
           email: user.email || undefined,
@@ -716,6 +719,12 @@ export const postToken = withRateLimit("token")(
         } satisfies SessionData;
         const s = await createSession(context, "user", sessionData);
         tokenResponse.refresh_token = s.refreshToken;
+      }
+      if (!issueRefreshToken) {
+        await context.db
+          .update(users)
+          .set({ lastActivityAt: new Date() })
+          .where(eq(users.sub, user.sub));
       }
 
       sendJson(response, 200, tokenResponse);

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -112,6 +112,7 @@ export const users = pgTable("users", {
   pendingEmail: text("pending_email"),
   pendingEmailSetAt: timestamp("pending_email_set_at"),
   passwordResetRequired: boolean("password_reset_required").default(false).notNull(),
+  lastActivityAt: timestamp("last_activity_at"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 

--- a/packages/api/src/models/users.ts
+++ b/packages/api/src/models/users.ts
@@ -113,7 +113,7 @@ export async function listUsers(
     page?: number;
     limit?: number;
     search?: string;
-    sortBy?: "createdAt" | "email" | "name" | "sub";
+    sortBy?: "createdAt" | "email" | "name" | "sub" | "lastActivityAt";
     sortOrder?: "asc" | "desc";
   } = {}
 ) {
@@ -130,7 +130,9 @@ export async function listUsers(
         ? users.name
         : sortBy === "sub"
           ? users.sub
-          : users.createdAt;
+          : sortBy === "lastActivityAt"
+            ? users.lastActivityAt
+            : users.createdAt;
 
   const baseQuery = context.db
     .select({
@@ -138,6 +140,7 @@ export async function listUsers(
       email: users.email,
       name: users.name,
       createdAt: users.createdAt,
+      lastActivityAt: users.lastActivityAt,
       passwordResetRequired: users.passwordResetRequired,
     })
     .from(users);
@@ -217,7 +220,7 @@ export async function createUser(
       }
     }
   });
-  return { sub, email, name, createdAt: new Date().toISOString() };
+  return { sub, email, name, createdAt: new Date().toISOString(), lastActivityAt: null };
 }
 
 export async function deleteUser(context: Context, sub: string) {
@@ -244,6 +247,7 @@ export async function getUsersBySubsWithAccess(context: Context, subs: string[])
       email: users.email,
       name: users.name,
       createdAt: users.createdAt,
+      lastActivityAt: users.lastActivityAt,
     })
     .from(users)
     .where(inArray(users.sub, subs));

--- a/packages/api/src/services/sessions.test.ts
+++ b/packages/api/src/services/sessions.test.ts
@@ -53,6 +53,23 @@ test("createSession stores a hashed refresh token", async () => {
   }
 });
 
+test("createSession updates user last activity", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "darkauth-sessions-test-"));
+  const { db, close } = await createPglite(directory);
+  const context = { db, logger: createLogger() } as Context;
+
+  try {
+    await db.insert(users).values({ sub: "user-1", email: "user-1@example.com", name: "User One" });
+    await createSession(context, "user", { sub: "user-1" });
+    const user = await db.query.users.findFirst({ where: eq(users.sub, "user-1") });
+
+    assert.ok(user?.lastActivityAt);
+  } finally {
+    await close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("refreshSessionWithToken allows only one success for concurrent refresh", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "darkauth-sessions-test-"));
   const { db, close } = await createPglite(directory);
@@ -73,6 +90,32 @@ test("refreshSessionWithToken allows only one success for concurrent refresh", a
     const activeSession = await getSession(context, successful[0].sessionId);
     assert.ok(activeSession);
     assert.equal(activeSession.sub, "user-1");
+  } finally {
+    await close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("refreshSessionWithToken updates user last activity", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "darkauth-sessions-test-"));
+  const { db, close } = await createPglite(directory);
+  const context = { db, logger: createLogger() } as Context;
+
+  try {
+    const oldActivity = new Date("2026-01-01T00:00:00.000Z");
+    await db.insert(users).values({
+      sub: "user-1",
+      email: "user-1@example.com",
+      name: "User One",
+      lastActivityAt: oldActivity,
+    });
+    const created = await createSession(context, "user", { sub: "user-1" });
+    await db.update(users).set({ lastActivityAt: oldActivity }).where(eq(users.sub, "user-1"));
+    await refreshSessionWithToken(context, created.refreshToken);
+    const user = await db.query.users.findFirst({ where: eq(users.sub, "user-1") });
+
+    assert.ok(user?.lastActivityAt);
+    assert.ok(user.lastActivityAt > oldActivity);
   } finally {
     await close();
     fs.rmSync(directory, { recursive: true, force: true });

--- a/packages/api/src/services/sessions.ts
+++ b/packages/api/src/services/sessions.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { and, eq, gt, isNull, lt } from "drizzle-orm";
-import { sessions } from "../db/schema.ts";
+import { sessions, users } from "../db/schema.ts";
 import { UnauthorizedError } from "../errors.ts";
 import type { Context, SessionData } from "../types.ts";
 import { generateRandomString, sha256Base64Url } from "../utils/crypto.ts";
@@ -212,6 +212,7 @@ export async function createSession(
   const refreshToken = generateRandomString(64);
   const refreshTokenHash = sha256Base64Url(refreshToken);
   const { sessionMs, refreshMs } = await getDurations(context, cohort);
+  const now = new Date();
   const expiresAt = new Date(Date.now() + sessionMs);
   const refreshTokenExpiresAt = new Date(Date.now() + refreshMs);
 
@@ -220,12 +221,16 @@ export async function createSession(
     cohort,
     userSub: data.sub,
     adminId: data.adminId,
-    createdAt: new Date(),
+    createdAt: now,
     expiresAt,
     refreshToken: refreshTokenHash,
     refreshTokenExpiresAt,
     data,
   });
+
+  if (cohort === "user" && data.sub) {
+    await context.db.update(users).set({ lastActivityAt: now }).where(eq(users.sub, data.sub));
+  }
 
   try {
     context.logger.info(
@@ -394,12 +399,19 @@ export async function refreshSessionWithToken(
       cohort: session.cohort,
       userSub: session.userSub,
       adminId: session.adminId,
-      createdAt: new Date(),
+      createdAt: now,
       expiresAt,
       refreshToken: newRefreshTokenHash,
       refreshTokenExpiresAt,
       data: session.data,
     });
+
+    if (session.cohort === "user" && session.userSub) {
+      await transaction
+        .update(users)
+        .set({ lastActivityAt: now })
+        .where(eq(users.sub, session.userSub));
+    }
 
     await transaction.delete(sessions).where(eq(sessions.id, session.id));
 


### PR DESCRIPTION
## Summary
- Add a nullable user last activity timestamp with a database migration and admin API sorting/response support.
- Update user activity on login/session creation, refresh-token rotation, and authorization-code token exchange without refresh tokens.
- Show last activity in the admin users table and user edit page.

## Verification
- `npm run tidy`
- `npm run build`
- `node --env-file-if-exists=../../.env --test src/services/sessions.test.ts src/controllers/admin/listEndpointsSchema.test.ts src/controllers/token.test.ts`
