### PR TITLE
feat(api,ui): add key unlock and passkey management

### DIFF
--- a/packages/api/src/controllers/user/authorizeFinalizeKeyDelivery.test.ts
+++ b/packages/api/src/controllers/user/authorizeFinalizeKeyDelivery.test.ts
@@ -278,6 +278,47 @@ test("authorize finalize allows locked SCIM sessions for ZK when policy disables
   }
 });
 
+test("authorize finalize does not store key delivery metadata for non-ZK requests", async () => {
+  const { context, cleanup } = await createContext();
+  try {
+    const organizationId = await createUserWithSessionAndOrg(context);
+    await createPendingAuth(context, {
+      requestId: "request-non-zk",
+      clientId: "client-id",
+      redirectUri: "https://client.example/callback",
+      scope: "openid",
+      state: "state",
+      origin: "https://auth.example.com",
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    await postAuthorizeFinalize(
+      context,
+      createRequest(
+        new URLSearchParams({
+          request_id: "request-non-zk",
+          approve: "true",
+          zk_key_hash: "unexpected-hash",
+          drk_hash: "unexpected-drk-hash",
+          organization_id: organizationId,
+        })
+      ),
+      createResponse()
+    );
+
+    const code = await context.db.query.authCodes.findFirst();
+    assert.ok(code);
+    assert.equal(code.hasZk, false);
+    assert.equal(code.zkPubKid, null);
+    assert.equal(code.zkKeyHash, null);
+    assert.equal(code.zkKeyKind, null);
+    assert.equal(code.zkKeyVersion, null);
+    assert.equal(code.drkHash, null);
+  } finally {
+    await cleanup();
+  }
+});
+
 test("authorize finalize keeps explicit v1 drk hash binding", async () => {
   const { context, cleanup } = await createContext();
   try {

--- a/packages/api/src/controllers/user/session.test.ts
+++ b/packages/api/src/controllers/user/session.test.ts
@@ -217,6 +217,7 @@ test("getSession returns current organization context", async () => {
       passwordResetRequired: false,
       otpRequired: false,
       otpVerified: false,
+      keyState: "locked",
       organizationId: organization.id,
       organizationSlug: "session-org",
     });

--- a/packages/api/src/controllers/user/webauthn.test.ts
+++ b/packages/api/src/controllers/user/webauthn.test.ts
@@ -16,7 +16,9 @@ import {
 import type { Context } from "../../types.ts";
 import { toBase64Url } from "../../utils/crypto.ts";
 import {
+  getWebAuthnCredentials,
   postPasskeyPrfEnvelope,
+  postWebAuthnCredentialRevoke,
   postWebAuthnLoginFinish,
   postWebAuthnLoginStart,
   postWebAuthnRegisterFinish,
@@ -457,6 +459,93 @@ test("passkey PRF envelope endpoint requires a PRF-capable credential and confir
       credential_id: "cred-prf",
       prf_result_confirmed: true,
     });
+  } finally {
+    await cleanup();
+  }
+});
+
+test("webauthn credentials endpoint lists and revokes passkeys", async () => {
+  const { context, cleanup } = await createContext();
+  try {
+    const sessionId = await createUserSession(context, "user-a");
+    await createAccountKey(context, { keyId: "ark_user-a_1", sub: "user-a" });
+    await createWebAuthnCredential(context, {
+      credentialId: "credential-auth-only",
+      sub: "user-a",
+      publicKey: Buffer.from("public-key"),
+      prfSupported: false,
+    });
+    await createWebAuthnCredential(context, {
+      credentialId: "credential-prf",
+      sub: "user-a",
+      publicKey: Buffer.from("public-key-prf"),
+      prfSupported: true,
+    });
+    await createPasskeyPrfEnvelope(context, {
+      credentialId: "credential-prf",
+      sub: "user-a",
+      keyId: "ark_user-a_1",
+      envelopeId: "env_prf",
+      wrappingAlg: "WebAuthn-PRF-HKDF-SHA256+A256GCM/v2",
+      wrappedKey: Buffer.from("wrapped-key"),
+      aad: Buffer.from("aad"),
+      prfSalt: Buffer.from("login-prf-salt-32-byte-value!!"),
+      prfResultConfirmed: true,
+    });
+
+    const listResponse = createResponse();
+    await getWebAuthnCredentials(
+      context,
+      createRequest({ method: "GET", url: "/webauthn/credentials", sessionId }),
+      listResponse
+    );
+    const listBody = listResponse.json as {
+      credentials: Array<{ credential_id: string; can_unlock: boolean }>;
+    };
+
+    assert.equal(listResponse.statusCode, 200);
+    assert.deepEqual(
+      listBody.credentials
+        .map((credential) => [credential.credential_id, credential.can_unlock])
+        .sort(),
+      [
+        ["credential-auth-only", false],
+        ["credential-prf", true],
+      ]
+    );
+
+    const revokeResponse = createResponse();
+    await postWebAuthnCredentialRevoke(
+      context,
+      createRequest({
+        method: "POST",
+        url: "/webauthn/credentials/credential-prf/revoke",
+        sessionId,
+      }),
+      revokeResponse,
+      "credential-prf"
+    );
+    const revokeBody = revokeResponse.json as {
+      credential: { credential_id: string; revoked_at: string };
+    };
+
+    assert.equal(revokeResponse.statusCode, 200);
+    assert.equal(revokeBody.credential.credential_id, "credential-prf");
+    assert.ok(revokeBody.credential.revoked_at);
+
+    const afterRevokeResponse = createResponse();
+    await getWebAuthnCredentials(
+      context,
+      createRequest({ method: "GET", url: "/webauthn/credentials", sessionId }),
+      afterRevokeResponse
+    );
+    const afterRevokeBody = afterRevokeResponse.json as {
+      credentials: Array<{ credential_id: string }>;
+    };
+    assert.deepEqual(
+      afterRevokeBody.credentials.map((credential) => credential.credential_id).sort(),
+      ["credential-auth-only"]
+    );
   } finally {
     await cleanup();
   }

--- a/packages/api/src/controllers/user/webauthn.ts
+++ b/packages/api/src/controllers/user/webauthn.ts
@@ -21,6 +21,7 @@ import {
   getWebAuthnCredential,
   listPasskeyPrfUnlockCandidates,
   listWebAuthnCredentials,
+  revokeWebAuthnCredential,
   updateWebAuthnCredentialUsage,
 } from "../../models/webauthn.ts";
 import {
@@ -342,6 +343,50 @@ export const postPasskeyPrfEnvelope = withAudit({
   })
 );
 
+export const getWebAuthnCredentials = withRateLimit("webauthn")(
+  async function getWebAuthnCredentials(
+    context: Context,
+    request: IncomingMessage,
+    response: ServerResponse
+  ) {
+    const session = await requireSession(context, request, false);
+    if (!session.sub) throw new UnauthorizedError("User session required");
+    const credentials = await listWebAuthnCredentials(context, session.sub);
+
+    sendJson(response, 200, {
+      credentials: credentials.map(serializePasskeyCredential),
+    });
+  }
+);
+
+export const postWebAuthnCredentialRevoke = withAudit({
+  eventType: "WEBAUTHN_CREDENTIAL_REVOKE",
+  resourceType: "webauthn_credential",
+  extractResourceId: (_body, params) => params[0],
+  skipBodyCapture: true,
+})(
+  withRateLimit("webauthn")(
+    async (
+      context: Context,
+      request: IncomingMessage,
+      response: ServerResponse,
+      credentialId?: string
+    ): Promise<void> => {
+      const session = await requireSession(context, request, false);
+      if (!session.sub) throw new UnauthorizedError("User session required");
+      if (!credentialId) throw new ValidationError("credential_id is required");
+      const credential = await revokeWebAuthnCredential(context, {
+        credentialId,
+        sub: session.sub,
+      });
+
+      sendJson(response, 200, {
+        credential: serializePasskeyCredential(credential),
+      });
+    }
+  )
+);
+
 export function serializePasskeyCredential(row: {
   credentialId: string;
   sub: string;
@@ -445,6 +490,22 @@ export const postPasskeyPrfEnvelopeSchema = {
   tags: ["WebAuthn"],
   summary: "createPasskeyPrfEnvelope",
   responses: { 201: { description: "Created" }, ...genericErrors },
+} as const satisfies ControllerSchema;
+
+export const getWebAuthnCredentialsSchema = {
+  method: "GET",
+  path: "/webauthn/credentials",
+  tags: ["WebAuthn"],
+  summary: "listWebAuthnCredentials",
+  responses: { 200: { description: "OK" }, ...genericErrors },
+} as const satisfies ControllerSchema;
+
+export const postWebAuthnCredentialRevokeSchema = {
+  method: "POST",
+  path: "/webauthn/credentials/{credential_id}/revoke",
+  tags: ["WebAuthn"],
+  summary: "revokeWebAuthnCredential",
+  responses: { 200: { description: "OK" }, ...genericErrors },
 } as const satisfies ControllerSchema;
 
 function parseBody<T>(schema: z.ZodType<T>, body: string): T {

--- a/packages/api/src/http/openapi.ts
+++ b/packages/api/src/http/openapi.ts
@@ -155,6 +155,8 @@ import {
 } from "../controllers/user/usersDirectory.ts";
 import {
   postPasskeyPrfEnvelopeSchema as userPasskeyPrfEnvelopeSchema,
+  postWebAuthnCredentialRevokeSchema as userWebAuthnCredentialRevokeSchema,
+  getWebAuthnCredentialsSchema as userWebAuthnCredentialsSchema,
   postWebAuthnLoginFinishSchema as userWebAuthnLoginFinishSchema,
   postWebAuthnLoginStartSchema as userWebAuthnLoginStartSchema,
   postWebAuthnRegisterFinishSchema as userWebAuthnRegisterFinishSchema,
@@ -270,6 +272,8 @@ const documentedSchemas: ControllerSchema[] = [
   userWebAuthnLoginStartSchema,
   userWebAuthnLoginFinishSchema,
   userPasskeyPrfEnvelopeSchema,
+  userWebAuthnCredentialsSchema,
+  userWebAuthnCredentialRevokeSchema,
   userRecoveryKeysSchema,
   userRecoveryKeySchema,
   userRecoveryKeyRevokeSchema,

--- a/packages/api/src/http/routers/userRouter.ts
+++ b/packages/api/src/http/routers/userRouter.ts
@@ -77,7 +77,9 @@ import {
   searchUserDirectory,
 } from "../../controllers/user/usersDirectory.ts";
 import {
+  getWebAuthnCredentials,
   postPasskeyPrfEnvelope,
+  postWebAuthnCredentialRevoke,
   postWebAuthnLoginFinish,
   postWebAuthnLoginStart,
   postWebAuthnRegisterFinish,
@@ -467,6 +469,22 @@ export function createUserRouter(context: Context) {
 
       if (method === "POST" && pathname === "/webauthn/prf-envelope") {
         return await postPasskeyPrfEnvelope(context, request, response);
+      }
+
+      if (method === "GET" && pathname === "/webauthn/credentials") {
+        return await getWebAuthnCredentials(context, request, response);
+      }
+
+      const webAuthnCredentialRevokeMatch = pathname.match(
+        /^\/webauthn\/credentials\/([^/]+)\/revoke$/
+      );
+      if (method === "POST" && webAuthnCredentialRevokeMatch) {
+        return await postWebAuthnCredentialRevoke(
+          context,
+          request,
+          response,
+          decodeURIComponent(webAuthnCredentialRevokeMatch[1] || "")
+        );
       }
 
       if (method === "GET" && pathname === "/crypto/wrapped-drk") {

--- a/packages/api/src/models/trustedDevices.test.ts
+++ b/packages/api/src/models/trustedDevices.test.ts
@@ -267,6 +267,61 @@ test("device approval consume verifies proof against requested public key hash",
   });
 });
 
+test("device approval AAD cannot be replayed across approval requests", async () => {
+  await withContext(async (context) => {
+    await createUser(context);
+    await createTrustedDeviceEnvelope(context);
+    const device = await createTrustedDevice(context, {
+      sub: "user-sub",
+      publicJwk: { kty: "EC", crv: "P-256", x: "x", y: "y" },
+      envelopeId: "env_user-sub_device_1",
+    });
+    const firstRequest = await createDeviceApprovalRequest(context, {
+      sub: "user-sub",
+      requesterSessionId: "session-1",
+      newDevicePublicJwk: { kty: "EC", crv: "P-256", x: "nx", y: "ny" },
+      metadata: {
+        client_id: "client-one",
+        state_hash: "state-hash-one",
+        verification_code_hash: "code-hash-one",
+      },
+    });
+    const secondRequest = await createDeviceApprovalRequest(context, {
+      sub: "user-sub",
+      requesterSessionId: "session-2",
+      newDevicePublicJwk: { kty: "EC", crv: "P-256", x: "nx", y: "ny" },
+      metadata: {
+        client_id: "client-two",
+        state_hash: "state-hash-two",
+        verification_code_hash: "code-hash-two",
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        approveDeviceApprovalRequest(context, {
+          sub: "user-sub",
+          requestId: secondRequest.requestId,
+          approvedByDeviceId: device.deviceId,
+          encryptedApproval: Buffer.from("encrypted-for-first-request"),
+          approvalAad: approvalAadFor(firstRequest),
+        }),
+      (error: unknown) => error instanceof ValidationError
+    );
+
+    const approved = await approveDeviceApprovalRequest(context, {
+      sub: "user-sub",
+      requestId: secondRequest.requestId,
+      approvedByDeviceId: device.deviceId,
+      encryptedApproval: Buffer.from("encrypted-for-second-request"),
+      approvalAad: approvalAadFor(secondRequest),
+    });
+
+    assert.equal(approved.status, "approved");
+    assert.equal(approved.requestId, secondRequest.requestId);
+  });
+});
+
 test("SCIM policy disables trusted-device approval", async () => {
   await withContext(async (context) => {
     await createUser(context);

--- a/packages/api/src/models/webauthn.test.ts
+++ b/packages/api/src/models/webauthn.test.ts
@@ -15,6 +15,7 @@ import {
   createWebAuthnCredential,
   credentialCanUnlockWithPrf,
   listWebAuthnCredentials,
+  revokeWebAuthnCredential,
 } from "./webauthn.ts";
 
 function createLogger() {
@@ -145,6 +146,45 @@ test("passkey credentials model auth-only passkeys separately from PRF unlock pa
     assert.equal(envelopes.length, 1);
     assert.equal(prfCredential?.prfEnvelopeId, "env_prf");
     assert.equal(prfCredential ? credentialCanUnlockWithPrf(prfCredential) : false, true);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("revoking a passkey also revokes its PRF envelope", async () => {
+  const { context, cleanup } = await createContext();
+  try {
+    await createUser(context);
+    await createAccountKey(context, { keyId: "ark_user-sub_1", sub: "user-sub" });
+    await createWebAuthnCredential(context, {
+      credentialId: "cred-prf",
+      sub: "user-sub",
+      publicKey: Buffer.from("public-key-prf"),
+      prfSupported: true,
+    });
+    await createPasskeyPrfEnvelope(context, {
+      credentialId: "cred-prf",
+      sub: "user-sub",
+      keyId: "ark_user-sub_1",
+      envelopeId: "env_prf",
+      wrappingAlg: "WebAuthn-PRF-HKDF-SHA256+A256GCM",
+      wrappedKey: Buffer.from("wrapped-key"),
+      aad: Buffer.from("aad"),
+      prfSalt: Buffer.from("prf-salt"),
+      prfResultConfirmed: true,
+    });
+
+    const revoked = await revokeWebAuthnCredential(context, {
+      credentialId: "cred-prf",
+      sub: "user-sub",
+    });
+    const activeCredentials = await listWebAuthnCredentials(context, "user-sub");
+    const activeEnvelopes = await listKeyEnvelopes(context, "user-sub", { type: "passkey_prf" });
+
+    assert.equal(revoked.credentialId, "cred-prf");
+    assert.ok(revoked.revokedAt);
+    assert.equal(activeCredentials.length, 0);
+    assert.equal(activeEnvelopes.length, 0);
   } finally {
     await cleanup();
   }

--- a/packages/api/src/models/webauthn.ts
+++ b/packages/api/src/models/webauthn.ts
@@ -128,10 +128,52 @@ export async function getWebAuthnChallenge(context: Context, challengeId: string
   return row;
 }
 
-export async function listWebAuthnCredentials(context: Context, sub: string) {
+export async function listWebAuthnCredentials(
+  context: Context,
+  sub: string,
+  options: { includeRevoked?: boolean } = {}
+) {
   validateIdentifier(sub, "sub");
+  const conditions = [eq(webauthnCredentials.sub, sub)];
+  if (!options.includeRevoked) conditions.push(isNull(webauthnCredentials.revokedAt));
   return await context.db.query.webauthnCredentials.findMany({
-    where: and(eq(webauthnCredentials.sub, sub), isNull(webauthnCredentials.revokedAt)),
+    where: and(...conditions),
+  });
+}
+
+export async function revokeWebAuthnCredential(
+  context: Context,
+  data: { credentialId: string; sub: string }
+) {
+  validateIdentifier(data.credentialId, "credentialId");
+  validateIdentifier(data.sub, "sub");
+  const now = new Date();
+  return await context.db.transaction(async (tx) => {
+    const [credential] = await tx
+      .update(webauthnCredentials)
+      .set({ revokedAt: now })
+      .where(
+        and(
+          eq(webauthnCredentials.credentialId, data.credentialId),
+          eq(webauthnCredentials.sub, data.sub),
+          isNull(webauthnCredentials.revokedAt)
+        )
+      )
+      .returning();
+    if (!credential) throw new NotFoundError("WebAuthn credential not found");
+    if (credential.prfEnvelopeId) {
+      await tx
+        .update(keyEnvelopes)
+        .set({ revokedAt: now })
+        .where(
+          and(
+            eq(keyEnvelopes.envelopeId, credential.prfEnvelopeId),
+            eq(keyEnvelopes.sub, data.sub),
+            isNull(keyEnvelopes.revokedAt)
+          )
+        );
+    }
+    return credential;
   });
 }
 

--- a/packages/user-ui/src/components/Dashboard.module.css
+++ b/packages/user-ui/src/components/Dashboard.module.css
@@ -116,7 +116,7 @@
   display: flex;
   justify-content: space-between;
   gap: 1rem;
-  align-items: center;
+  align-items: flex-start;
   margin-bottom: 1.5rem;
   padding: 1rem;
   border: 1px solid #f59e0b;

--- a/packages/user-ui/src/components/Dashboard.test.js
+++ b/packages/user-ui/src/components/Dashboard.test.js
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const dashboardSource = readFileSync(resolve(here, "Dashboard.tsx"), "utf8");
+const layoutSource = readFileSync(resolve(here, "UserLayout.tsx"), "utf8");
+const unlockSource = readFileSync(resolve(here, "KeyUnlockPanel.tsx"), "utf8");
+
+test("dashboard and account menu expose passkey security settings", () => {
+  assert.notEqual(dashboardSource.indexOf("Passkeys & Security"), -1);
+  assert.notEqual(layoutSource.indexOf("Passkeys & Security"), -1);
+  assert.notEqual(dashboardSource.indexOf("KeyUnlockPanel"), -1);
+  assert.notEqual(unlockSource.indexOf("Unlock with Password"), -1);
+  assert.equal(dashboardSource.indexOf("Reset OTP"), -1);
+  assert.equal(layoutSource.indexOf("Resetup OTP"), -1);
+});

--- a/packages/user-ui/src/components/Dashboard.tsx
+++ b/packages/user-ui/src/components/Dashboard.tsx
@@ -2,14 +2,18 @@ import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import apiService from "../services/api";
 import { logger } from "../services/logger";
+import { loadUnlockedArk } from "../services/unlockedArk";
 import styles from "./Dashboard.module.css";
+import KeyUnlockPanel from "./KeyUnlockPanel";
 import UserLayout from "./UserLayout";
+
+type KeyState = "locked" | "unlocked" | "setup_required";
 
 interface SessionData {
   sub: string;
   name?: string;
   email?: string;
-  keyState?: "locked" | "unlocked" | "setup_required";
+  keyState?: KeyState;
 }
 
 interface App {
@@ -29,10 +33,17 @@ interface DashboardProps {
   onLogout: () => void;
 }
 
+function resolveKeyState(sessionData: SessionData): KeyState {
+  return sessionData.keyState === "unlocked" || loadUnlockedArk(sessionData.sub)
+    ? "unlocked"
+    : sessionData.keyState || "locked";
+}
+
 export default function Dashboard({ sessionData, onLogout }: DashboardProps) {
   const navigate = useNavigate();
   const [apps, setApps] = useState<App[]>([]);
   const [loading, setLoading] = useState(true);
+  const [keyState, setKeyState] = useState<KeyState>(resolveKeyState(sessionData));
 
   const loadUserApps = useCallback(async () => {
     try {
@@ -50,6 +61,10 @@ export default function Dashboard({ sessionData, onLogout }: DashboardProps) {
     loadUserApps();
   }, [loadUserApps]);
 
+  useEffect(() => {
+    setKeyState(resolveKeyState(sessionData));
+  }, [sessionData]);
+
   return (
     <UserLayout
       userName={sessionData.name || null}
@@ -59,15 +74,14 @@ export default function Dashboard({ sessionData, onLogout }: DashboardProps) {
       onLogout={onLogout}
     >
       <div className={styles.container}>
-        {sessionData.keyState && sessionData.keyState !== "unlocked" ? (
+        {keyState !== "unlocked" ? (
           <section className={styles.keyStateBanner}>
-            <div>
-              <h3>Encryption keys locked</h3>
-              <p>
-                You are signed in, but zero-knowledge app access needs a password, passkey, recovery
-                key, or trusted-device unlock.
-              </p>
-            </div>
+            <KeyUnlockPanel
+              sub={sessionData.sub}
+              email={sessionData.email}
+              inline
+              onUnlocked={(session) => setKeyState(session?.keyState || "unlocked")}
+            />
             <button
               type="button"
               className={styles.appsActionButton}
@@ -200,7 +214,7 @@ export default function Dashboard({ sessionData, onLogout }: DashboardProps) {
                 className={styles.appsActionButton}
                 onClick={() => navigate("/settings")}
               >
-                Reset OTP
+                Passkeys & Security
               </button>
             </div>
           </section>

--- a/packages/user-ui/src/components/KeyUnlockPanel.module.css
+++ b/packages/user-ui/src/components/KeyUnlockPanel.module.css
@@ -1,0 +1,142 @@
+.panel {
+  width: 100%;
+  border: 1px solid #f59e0b;
+  border-radius: 0.75rem;
+  background: #fffbeb;
+  padding: 1rem;
+  text-align: left;
+}
+
+.inlinePanel {
+  border: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.summary {
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.copy {
+  min-width: 0;
+}
+
+.title {
+  margin: 0 0 0.25rem;
+  color: #92400e;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.description {
+  margin: 0;
+  color: #78350f;
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
+.form {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.field {
+  display: grid;
+  gap: 0.375rem;
+}
+
+.field label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #78350f;
+}
+
+.field input {
+  width: 100%;
+  border: 1px solid #fbbf24;
+  border-radius: 0.5rem;
+  padding: 0.7rem 0.8rem;
+  background: white;
+  color: #111827;
+  font-size: 1rem;
+}
+
+.field input:focus {
+  outline: none;
+  border-color: var(--primary-500);
+  box-shadow: 0 0 0 3px rgb(245 158 11 / 0.2);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.error,
+.success {
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  font-size: 0.875rem;
+}
+
+.error {
+  border: 1px solid #fecaca;
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.success {
+  border: 1px solid #bbf7d0;
+  background: #f0fdf4;
+  color: #166534;
+}
+
+@media (max-width: 768px) {
+  .summary {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+
+[data-da-theme="dark"] .panel {
+  border-color: #92400e;
+  background: #451a0399;
+}
+
+[data-da-theme="dark"] .inlinePanel {
+  border: 0;
+  background: transparent;
+}
+
+[data-da-theme="dark"] .title {
+  color: #fbbf24;
+}
+
+[data-da-theme="dark"] .description,
+[data-da-theme="dark"] .field label {
+  color: #fde68a;
+}
+
+[data-da-theme="dark"] .field input {
+  border-color: #92400e;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+[data-da-theme="dark"] .error {
+  border-color: #f871714d;
+  background: #7f1d1d33;
+  color: #fca5a5;
+}
+
+[data-da-theme="dark"] .success {
+  border-color: #22c55e4d;
+  background: #14532d33;
+  color: #86efac;
+}

--- a/packages/user-ui/src/components/KeyUnlockPanel.test.js
+++ b/packages/user-ui/src/components/KeyUnlockPanel.test.js
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(resolve(here, "KeyUnlockPanel.tsx"), "utf8");
+
+test("key unlock panel uses password proof before marking keys unlocked", () => {
+  assert.notEqual(source.indexOf("Unlock with Password"), -1);
+  assert.notEqual(source.indexOf("opaqueService.startLogin"), -1);
+  assert.notEqual(source.indexOf("api.passwordVerifyFinish"), -1);
+  assert.notEqual(source.indexOf("saveUnlockedArk"), -1);
+  assert.equal(source.indexOf("session/key-unlock"), -1);
+});

--- a/packages/user-ui/src/components/KeyUnlockPanel.tsx
+++ b/packages/user-ui/src/components/KeyUnlockPanel.tsx
@@ -1,0 +1,306 @@
+import { useId, useState } from "react";
+import api, { type KeyEnvelopeResponse, type SessionResponse } from "../services/api";
+import cryptoService, { fromBase64Url } from "../services/crypto";
+import deviceKeyStore from "../services/deviceKeyStore";
+import opaqueService from "../services/opaque";
+import { loadExportKey, saveExportKey } from "../services/sessionKey";
+import { loadUnlockedArk, saveUnlockedArk } from "../services/unlockedArk";
+import Button from "./Button";
+import styles from "./KeyUnlockPanel.module.css";
+
+interface KeyUnlockPanelProps {
+  sub: string;
+  email?: string | null;
+  inline?: boolean;
+  onUnlocked?: (session: SessionResponse | null) => void;
+}
+
+const textEncoder = new TextEncoder();
+
+async function deriveV2PasswordWrapKey(exportKey: Uint8Array, sub: string): Promise<Uint8Array> {
+  const salt = new Uint8Array(
+    await crypto.subtle.digest("SHA-256", textEncoder.encode(`DarkAuth|v2|password|sub=${sub}`))
+  );
+  const masterKey = await cryptoService.hkdf(exportKey, salt, textEncoder.encode("mk"), 32);
+  try {
+    return await cryptoService.hkdf(
+      masterKey,
+      textEncoder.encode("DarkAuth|v2"),
+      textEncoder.encode("account-root-wrap"),
+      32
+    );
+  } finally {
+    cryptoService.clearSensitiveData(masterKey);
+  }
+}
+
+function normalizeArk(unwrapped: Uint8Array, envelope?: KeyEnvelopeResponse): Uint8Array {
+  if (unwrapped.length === 32) return new Uint8Array(unwrapped);
+  const decoded = new TextDecoder().decode(unwrapped);
+  const parsed = JSON.parse(decoded) as {
+    typ?: string;
+    version?: string;
+    sub?: string;
+    key_id?: string;
+    ark?: string;
+  };
+  if (
+    parsed.typ !== "DarkAuth-Account-Root-Key" ||
+    parsed.version !== "v2" ||
+    !parsed.ark ||
+    (envelope && (parsed.sub !== envelope.sub || parsed.key_id !== envelope.key_id))
+  ) {
+    throw new Error("Invalid password envelope plaintext");
+  }
+  const ark = fromBase64Url(parsed.ark);
+  if (ark.length !== 32) throw new Error("Invalid account root key length");
+  return ark;
+}
+
+async function unwrapPasswordEnvelopeWithKey(
+  envelope: KeyEnvelopeResponse,
+  exportKey: Uint8Array
+): Promise<Uint8Array> {
+  let v2WrapKey: Uint8Array | null = null;
+  let legacyKeys: Awaited<ReturnType<typeof cryptoService.deriveKeysFromExportKey>> | null = null;
+  try {
+    v2WrapKey = await deriveV2PasswordWrapKey(exportKey, envelope.sub);
+    const unwrapped = await cryptoService.unwrapKeyMaterial(
+      fromBase64Url(envelope.wrapped_key),
+      v2WrapKey,
+      fromBase64Url(envelope.aad)
+    );
+    try {
+      return normalizeArk(unwrapped, envelope);
+    } finally {
+      cryptoService.clearSensitiveData(unwrapped);
+    }
+  } catch (firstError) {
+    try {
+      legacyKeys = await cryptoService.deriveKeysFromExportKey(exportKey, envelope.sub);
+      const unwrapped = await cryptoService.unwrapKeyMaterial(
+        fromBase64Url(envelope.wrapped_key),
+        legacyKeys.wrapKey,
+        fromBase64Url(envelope.aad)
+      );
+      try {
+        return normalizeArk(unwrapped, envelope);
+      } finally {
+        cryptoService.clearSensitiveData(unwrapped);
+      }
+    } catch {
+      throw firstError;
+    }
+  } finally {
+    const arraysToClear = [
+      v2WrapKey,
+      legacyKeys?.masterKey,
+      legacyKeys?.wrapKey,
+      legacyKeys?.deriveKey,
+    ].filter((value): value is Uint8Array => value instanceof Uint8Array);
+    if (arraysToClear.length > 0) cryptoService.clearSensitiveData(...arraysToClear);
+  }
+}
+
+export async function unlockArkWithExportKey(
+  sub: string,
+  exportKey: Uint8Array
+): Promise<Uint8Array> {
+  const keybag = await api.getKeybag().catch(() => null);
+  const passwordEnvelope = keybag?.envelopes.find(
+    (envelope) => envelope.sub === sub && !envelope.revoked_at && envelope.type === "password"
+  );
+  if (passwordEnvelope) {
+    return unwrapPasswordEnvelopeWithKey(passwordEnvelope, exportKey);
+  }
+  const legacyKeys = await cryptoService.deriveKeysFromExportKey(exportKey, sub);
+  try {
+    return await cryptoService.unwrapDRK(
+      fromBase64Url(await api.getWrappedDrk()),
+      legacyKeys.wrapKey,
+      sub
+    );
+  } finally {
+    cryptoService.clearSensitiveData(
+      legacyKeys.masterKey,
+      legacyKeys.wrapKey,
+      legacyKeys.deriveKey
+    );
+  }
+}
+
+export async function unlockArkWithLocalTrustedDevice(sub: string): Promise<Uint8Array | null> {
+  const [keybag, devices] = await Promise.all([
+    api.getKeybag().catch(() => null),
+    api.getTrustedDevices().catch(() => []),
+  ]);
+  const handleByEnvelopeId = new Map<string, string>();
+  for (const device of devices) {
+    if (device.sub && device.sub !== sub) continue;
+    const metadataHandle = device.key_handle_metadata?.key_handle;
+    const handle =
+      device.key_handle || (typeof metadataHandle === "string" ? metadataHandle : null);
+    if (!device.revoked_at && device.envelope_id && handle) {
+      handleByEnvelopeId.set(device.envelope_id, handle);
+    }
+  }
+  for (const envelope of keybag?.envelopes ?? []) {
+    if (envelope.sub !== sub || envelope.revoked_at || envelope.type !== "trusted_device") continue;
+    const metadata = envelope.metadata || {};
+    const handle =
+      typeof metadata.key_handle === "string"
+        ? metadata.key_handle
+        : typeof metadata.handle === "string"
+          ? metadata.handle
+          : handleByEnvelopeId.get(envelope.envelope_id) || null;
+    if (!handle) continue;
+    const localKey = await deviceKeyStore.getKey(handle).catch(() => null);
+    if (!localKey) continue;
+    const unwrapped = await cryptoService.unwrapKeyMaterialWithAesKey(
+      fromBase64Url(envelope.wrapped_key),
+      localKey,
+      fromBase64Url(envelope.aad)
+    );
+    try {
+      return normalizeArk(unwrapped, envelope);
+    } finally {
+      cryptoService.clearSensitiveData(unwrapped);
+    }
+  }
+  return null;
+}
+
+export async function loadArkFromAvailableLocalUnlocks(sub: string): Promise<Uint8Array | null> {
+  const existing = loadUnlockedArk(sub);
+  if (existing) return existing;
+  const trustedArk = await unlockArkWithLocalTrustedDevice(sub);
+  if (trustedArk) {
+    saveUnlockedArk(sub, trustedArk);
+    return trustedArk;
+  }
+  const exportKey = await loadExportKey(sub);
+  if (!exportKey) return null;
+  try {
+    const ark = await unlockArkWithExportKey(sub, exportKey);
+    saveUnlockedArk(sub, ark);
+    return ark;
+  } finally {
+    cryptoService.clearSensitiveData(exportKey);
+  }
+}
+
+export default function KeyUnlockPanel({
+  sub,
+  email,
+  inline = false,
+  onUnlocked,
+}: KeyUnlockPanelProps) {
+  const passwordId = useId();
+  const [expanded, setExpanded] = useState(false);
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const unlockWithPassword = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!email) {
+      setError("Your account email is required to unlock with password.");
+      return;
+    }
+    if (!password) {
+      setError("Enter your DarkAuth password.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    setSuccess(null);
+    let exportKey: Uint8Array | null = null;
+    let sessionKey: Uint8Array | null = null;
+    let ark: Uint8Array | null = null;
+    let started: Awaited<ReturnType<typeof opaqueService.startLogin>> | null = null;
+    try {
+      started = await opaqueService.startLogin(email, password);
+      const verifyStart = await api.passwordVerifyStart(started.request);
+      const finish = await opaqueService.finishLogin(verifyStart.message, started.state);
+      exportKey = finish.exportKey;
+      sessionKey = finish.sessionKey;
+      ark = await unlockArkWithExportKey(sub, exportKey);
+      await api.passwordVerifyFinish(finish.request, verifyStart.sessionId);
+      await saveExportKey(sub, exportKey);
+      saveUnlockedArk(sub, ark);
+      setPassword("");
+      setExpanded(false);
+      setSuccess("Encryption keys unlocked for this browser session.");
+      const session = await api.getSession().catch(() => null);
+      onUnlocked?.(session);
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : "Password unlock failed";
+      setError(
+        message.toLowerCase().includes("auth") || message.toLowerCase().includes("opaque")
+          ? "DarkAuth password is incorrect."
+          : message
+      );
+    } finally {
+      if (started) opaqueService.clearState(started.state);
+      const arraysToClear = [exportKey, sessionKey, ark].filter(
+        (value): value is Uint8Array => value instanceof Uint8Array
+      );
+      if (arraysToClear.length > 0) cryptoService.clearSensitiveData(...arraysToClear);
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className={inline ? styles.inlinePanel : styles.panel}>
+      <div className={styles.summary}>
+        <div className={styles.copy}>
+          <h3 className={styles.title}>Encryption keys locked</h3>
+          <p className={styles.description}>
+            You are signed in, but encrypted app access and key management need a local key unlock.
+          </p>
+        </div>
+        {!expanded && (
+          <Button type="button" variant="primary" onClick={() => setExpanded(true)}>
+            Unlock with Password
+          </Button>
+        )}
+      </div>
+      {expanded && (
+        <form className={styles.form} onSubmit={unlockWithPassword}>
+          <div className={styles.field}>
+            <label htmlFor={passwordId}>DarkAuth password</label>
+            <input
+              id={passwordId}
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              autoComplete="current-password"
+              placeholder="Enter your DarkAuth password"
+              disabled={loading}
+            />
+          </div>
+          <div className={styles.actions}>
+            <Button type="submit" variant="primary" disabled={loading}>
+              {loading ? "Unlocking..." : "Unlock with Password"}
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={loading}
+              onClick={() => {
+                setExpanded(false);
+                setPassword("");
+                setError(null);
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+      )}
+      {error && <div className={styles.error}>{error}</div>}
+      {success && <div className={styles.success}>{success}</div>}
+    </div>
+  );
+}

--- a/packages/user-ui/src/components/SettingsSecurity.test.js
+++ b/packages/user-ui/src/components/SettingsSecurity.test.js
@@ -6,6 +6,8 @@ import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const source = readFileSync(resolve(here, "SettingsSecurity.tsx"), "utf8");
+const settingsViewSource = readFileSync(resolve(here, "SettingsSecurityView.tsx"), "utf8");
+const unlockSource = readFileSync(resolve(here, "KeyUnlockPanel.tsx"), "utf8");
 const apiSource = readFileSync(resolve(here, "../services/api.ts"), "utf8");
 
 test("Settings security manages trusted devices and approval requests", () => {
@@ -31,6 +33,10 @@ test("Settings security distinguishes passkey authentication from PRF unlock", (
   assert.notEqual(source.indexOf("verified WebAuthn PRF support"), -1);
   assert.notEqual(source.indexOf("Auth + unlock passkeys"), -1);
   assert.notEqual(source.indexOf("Auth-only passkeys"), -1);
+  assert.notEqual(source.indexOf("api.getWebAuthnCredentials"), -1);
+  assert.notEqual(source.indexOf("api.revokeWebAuthnCredential"), -1);
+  assert.notEqual(source.indexOf("Sign-in and encryption unlock"), -1);
+  assert.notEqual(source.indexOf("Sign-in only"), -1);
   assert.notEqual(source.indexOf("registerPasskey"), -1);
   assert.notEqual(source.indexOf("api.webAuthnRegisterStart"), -1);
   assert.notEqual(source.indexOf("api.createPasskeyPrfEnvelope"), -1);
@@ -48,4 +54,22 @@ test("Settings security creates high entropy recovery key envelopes", () => {
   assert.notEqual(apiSource.indexOf("RecoveryKeyCreateRequest"), -1);
   assert.notEqual(apiSource.indexOf("/crypto/recovery-keys"), -1);
   assert.equal(apiSource.indexOf("/crypto/keybag/recovery"), -1);
+});
+
+test("dashboard and settings expose password unlock for locked key state", () => {
+  assert.notEqual(settingsViewSource.indexOf("KeyUnlockPanel"), -1);
+  assert.notEqual(unlockSource.indexOf("Unlock with Password"), -1);
+  assert.notEqual(unlockSource.indexOf("opaqueService.startLogin"), -1);
+  assert.notEqual(unlockSource.indexOf("api.passwordVerifyFinish"), -1);
+  assert.notEqual(unlockSource.indexOf("unlockArkWithExportKey"), -1);
+  assert.notEqual(unlockSource.indexOf("saveUnlockedArk"), -1);
+  assert.notEqual(unlockSource.indexOf('type === "password"'), -1);
+});
+
+test("trusted device actions use unlocked ARK instead of requiring export key", () => {
+  assert.notEqual(source.indexOf("loadArkFromAvailableLocalUnlocks"), -1);
+  assert.equal(source.indexOf("loadExportKey"), -1);
+  assert.notEqual(unlockSource.indexOf("unlockArkWithLocalTrustedDevice"), -1);
+  assert.notEqual(unlockSource.indexOf("deviceKeyStore.getKey"), -1);
+  assert.notEqual(source.indexOf("This browser is trusted for encrypted key approvals."), -1);
 });

--- a/packages/user-ui/src/components/SettingsSecurity.tsx
+++ b/packages/user-ui/src/components/SettingsSecurity.tsx
@@ -5,11 +5,10 @@ import api, {
   type KeybagResponse,
   type RecoveryKeyResponse,
   type TrustedDeviceResponse,
+  type WebAuthnCredentialResponse,
 } from "../services/api";
-import cryptoService, { fromBase64Url, toBase64Url } from "../services/crypto";
+import cryptoService, { toBase64Url } from "../services/crypto";
 import deviceKeyStore from "../services/deviceKeyStore";
-import { loadExportKey } from "../services/sessionKey";
-import { loadUnlockedArk, saveUnlockedArk } from "../services/unlockedArk";
 import {
   createPasskeyCredential,
   derivePasskeyPrfWrapKey,
@@ -18,11 +17,16 @@ import {
   serializeRegistrationResponse,
 } from "../services/webauthn";
 import Button from "./Button";
+import { loadArkFromAvailableLocalUnlocks } from "./KeyUnlockPanel";
 
 export default function SettingsSecurity({
   sessionData,
 }: {
-  sessionData: { sub: string; email?: string };
+  sessionData: {
+    sub: string;
+    email?: string;
+    keyState?: "locked" | "unlocked" | "setup_required";
+  };
 }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -43,11 +47,14 @@ export default function SettingsSecurity({
   const [deviceApprovals, setDeviceApprovals] = useState<DeviceApprovalResponse[]>([]);
   const [deviceActionLoading, setDeviceActionLoading] = useState<string | null>(null);
   const [trustDeviceLoading, setTrustDeviceLoading] = useState(false);
+  const [trustedDeviceMessage, setTrustedDeviceMessage] = useState<string | null>(null);
   const [recoveryKeys, setRecoveryKeys] = useState<RecoveryKeyResponse[]>([]);
   const [recoverySecret, setRecoverySecret] = useState<string | null>(null);
   const [recoveryActionLoading, setRecoveryActionLoading] = useState<string | null>(null);
   const [passkeyActionLoading, setPasskeyActionLoading] = useState(false);
+  const [passkeyRevokeLoading, setPasskeyRevokeLoading] = useState<string | null>(null);
   const [passkeyMessage, setPasskeyMessage] = useState<string | null>(null);
+  const [passkeys, setPasskeys] = useState<WebAuthnCredentialResponse[]>([]);
   const [passkeyCompatibility, setPasskeyCompatibility] = useState<{
     webauthn: boolean;
     platformAuthenticator: boolean | null;
@@ -61,18 +68,20 @@ export default function SettingsSecurity({
       setLoading(true);
       setError(null);
       setBackupCodes(null);
-      const [s, keys, devices, approvals, recovery] = await Promise.all([
+      const [s, keys, devices, approvals, recovery, credentials] = await Promise.all([
         api.getOtpStatus(),
         api.getKeybag().catch(() => null),
         api.getTrustedDevices(),
         api.getDeviceApprovals(),
         api.getRecoveryKeys().catch(() => []),
+        api.getWebAuthnCredentials().catch(() => []),
       ]);
       setStatus(s);
       setKeybag(keys);
       setTrustedDevices(devices);
       setDeviceApprovals(approvals);
       setRecoveryKeys(recovery);
+      setPasskeys(credentials);
       setProvisioningUri(null);
       setSecret(null);
     } catch (e) {
@@ -167,25 +176,7 @@ export default function SettingsSecurity({
     return accountKey.key_id;
   };
 
-  const getUnlockedArk = async () => {
-    const existing = loadUnlockedArk(sessionData.sub);
-    if (existing) return existing;
-    const exportKey = await loadExportKey(sessionData.sub);
-    if (!exportKey) return null;
-    try {
-      const wrappedDrk = fromBase64Url(await api.getWrappedDrk());
-      const keys = await cryptoService.deriveKeysFromExportKey(exportKey, sessionData.sub);
-      try {
-        const ark = await cryptoService.unwrapDRK(wrappedDrk, keys.wrapKey, sessionData.sub);
-        saveUnlockedArk(sessionData.sub, ark);
-        return ark;
-      } finally {
-        cryptoService.clearSensitiveData(keys.masterKey, keys.wrapKey, keys.deriveKey);
-      }
-    } finally {
-      cryptoService.clearSensitiveData(exportKey);
-    }
-  };
+  const getUnlockedArk = async () => loadArkFromAvailableLocalUnlocks(sessionData.sub);
 
   const registerPasskey = async () => {
     let ark: Uint8Array | null = null;
@@ -259,7 +250,12 @@ export default function SettingsSecurity({
           "Passkey registered for sign-in. This authenticator did not return PRF unlock material."
         );
       }
-      setKeybag(await api.getKeybag().catch(() => null));
+      const [keysAfterRegister, passkeysAfterRegister] = await Promise.all([
+        api.getKeybag().catch(() => null),
+        api.getWebAuthnCredentials().catch(() => []),
+      ]);
+      setKeybag(keysAfterRegister);
+      setPasskeys(passkeysAfterRegister);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to register passkey");
     } finally {
@@ -273,10 +269,28 @@ export default function SettingsSecurity({
     }
   };
 
+  const revokePasskey = async (credentialId: string) => {
+    try {
+      setPasskeyRevokeLoading(credentialId);
+      setPasskeyMessage(null);
+      setError(null);
+      await api.revokeWebAuthnCredential(credentialId);
+      const [keysAfterRevoke, passkeysAfterRevoke] = await Promise.all([
+        api.getKeybag().catch(() => null),
+        api.getWebAuthnCredentials().catch(() => []),
+      ]);
+      setKeybag(keysAfterRevoke);
+      setPasskeys(passkeysAfterRevoke);
+      setPasskeyMessage("Passkey revoked.");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to revoke passkey");
+    } finally {
+      setPasskeyRevokeLoading(null);
+    }
+  };
+
   const createRecoveryKey = async () => {
-    let exportKey: Uint8Array | null = null;
     let ark: Uint8Array | null = null;
-    let keys: Awaited<ReturnType<typeof cryptoService.deriveKeysFromExportKey>> | null = null;
     let secretBytes: Uint8Array | null = null;
     let recoveryWrapKey: Uint8Array | null = null;
     let verifier: Uint8Array | null = null;
@@ -285,14 +299,11 @@ export default function SettingsSecurity({
       setRecoveryActionLoading("create");
       setRecoverySecret(null);
       setError(null);
-      exportKey = await loadExportKey(sessionData.sub);
-      if (!exportKey) {
-        throw new Error("Unlock this browser with your password before creating a recovery key.");
+      ark = await getUnlockedArk();
+      if (!ark) {
+        throw new Error("Unlock this browser before creating a recovery key.");
       }
       const keyId = await getOrCreateAccountKeyId();
-      const wrappedDrk = fromBase64Url(await api.getWrappedDrk());
-      keys = await cryptoService.deriveKeysFromExportKey(exportKey, sessionData.sub);
-      ark = await cryptoService.unwrapDRK(wrappedDrk, keys.wrapKey, sessionData.sub);
       secretBytes = new Uint8Array(32);
       crypto.getRandomValues(secretBytes);
       const secret = toBase64Url(secretBytes);
@@ -330,17 +341,9 @@ export default function SettingsSecurity({
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to create recovery key");
     } finally {
-      const arraysToClear = [
-        exportKey,
-        ark,
-        keys?.masterKey,
-        keys?.wrapKey,
-        keys?.deriveKey,
-        secretBytes,
-        recoveryWrapKey,
-        verifier,
-        wrappedKey,
-      ].filter((value): value is Uint8Array => value instanceof Uint8Array);
+      const arraysToClear = [ark, secretBytes, recoveryWrapKey, verifier, wrappedKey].filter(
+        (value): value is Uint8Array => value instanceof Uint8Array
+      );
       if (arraysToClear.length > 0) {
         cryptoService.clearSensitiveData(...arraysToClear);
       }
@@ -380,22 +383,18 @@ export default function SettingsSecurity({
   };
 
   const trustCurrentDevice = async () => {
-    let exportKey: Uint8Array | null = null;
     let ark: Uint8Array | null = null;
-    let keys: Awaited<ReturnType<typeof cryptoService.deriveKeysFromExportKey>> | null = null;
     let wrappedKey: Uint8Array | null = null;
     let handle: string | null = null;
     try {
       setTrustDeviceLoading(true);
       setError(null);
-      exportKey = await loadExportKey(sessionData.sub);
-      if (!exportKey) {
-        throw new Error("Unlock this browser with your password before trusting this device.");
+      setTrustedDeviceMessage(null);
+      ark = await getUnlockedArk();
+      if (!ark) {
+        throw new Error("Unlock this browser before trusting this device.");
       }
       const keyId = await getOrCreateAccountKeyId();
-      const wrappedDrk = fromBase64Url(await api.getWrappedDrk());
-      keys = await cryptoService.deriveKeysFromExportKey(exportKey, sessionData.sub);
-      ark = await cryptoService.unwrapDRK(wrappedDrk, keys.wrapKey, sessionData.sub);
       const localKey = await deviceKeyStore.createKeyHandle(sessionData.sub);
       handle = localKey.handle;
       const envelopeId = `env_${crypto.randomUUID()}`;
@@ -430,20 +429,16 @@ export default function SettingsSecurity({
       ]);
       setKeybag(keysAfterTrust);
       setTrustedDevices(devicesAfterTrust);
+      setTrustedDeviceMessage("This browser is trusted for encrypted key approvals.");
     } catch (e) {
       if (handle) {
         await deviceKeyStore.deleteKey(handle).catch(() => {});
       }
       setError(e instanceof Error ? e.message : "Failed to trust this device");
     } finally {
-      const arraysToClear = [
-        exportKey,
-        ark,
-        keys?.masterKey,
-        keys?.wrapKey,
-        keys?.deriveKey,
-        wrappedKey,
-      ].filter((value): value is Uint8Array => value instanceof Uint8Array);
+      const arraysToClear = [ark, wrappedKey].filter(
+        (value): value is Uint8Array => value instanceof Uint8Array
+      );
       if (arraysToClear.length > 0) {
         cryptoService.clearSensitiveData(...arraysToClear);
       }
@@ -477,19 +472,14 @@ export default function SettingsSecurity({
       return;
     }
 
-    let exportKey: Uint8Array | null = null;
     let ark: Uint8Array | null = null;
-    let keys: Awaited<ReturnType<typeof cryptoService.deriveKeysFromExportKey>> | null = null;
     try {
       setDeviceActionLoading(requestId);
       setError(null);
-      exportKey = await loadExportKey(sessionData.sub);
-      if (!exportKey) {
-        throw new Error("Unlock this browser with your password before approving another device.");
+      ark = await getUnlockedArk();
+      if (!ark) {
+        throw new Error("Unlock this browser before approving another device.");
       }
-      const wrappedDrk = fromBase64Url(await api.getWrappedDrk());
-      keys = await cryptoService.deriveKeysFromExportKey(exportKey, sessionData.sub);
-      ark = await cryptoService.unwrapDRK(wrappedDrk, keys.wrapKey, sessionData.sub);
       const encryptedApproval = await cryptoService.createDeviceApprovalJWE(
         ark,
         recipientPublicJwk,
@@ -506,13 +496,9 @@ export default function SettingsSecurity({
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to approve device");
     } finally {
-      const arraysToClear = [
-        exportKey,
-        ark,
-        keys?.masterKey,
-        keys?.wrapKey,
-        keys?.deriveKey,
-      ].filter((value): value is Uint8Array => value instanceof Uint8Array);
+      const arraysToClear = [ark].filter(
+        (value): value is Uint8Array => value instanceof Uint8Array
+      );
       if (arraysToClear.length > 0) {
         cryptoService.clearSensitiveData(...arraysToClear);
       }
@@ -522,7 +508,9 @@ export default function SettingsSecurity({
 
   const activeTrustedDevices = trustedDevices.filter((device) => !device.revoked_at);
   const activeEnvelopes = keybag?.envelopes.filter((envelope) => !envelope.revoked_at) ?? [];
-  const passkeyPrfEnvelopes = activeEnvelopes.filter((envelope) => envelope.type === "passkey_prf");
+  const activePasskeys = passkeys.filter((passkey) => !passkey.revoked_at);
+  const unlockPasskeys = activePasskeys.filter((passkey) => passkey.can_unlock);
+  const authOnlyPasskeys = activePasskeys.filter((passkey) => !passkey.can_unlock);
   const recoveryEnvelopes = activeEnvelopes.filter((envelope) => envelope.type === "recovery");
   const activeRecoveryKeys = recoveryKeys.filter((key) => !key.revoked_at);
   const pendingApprovals = deviceApprovals.filter((approval) => {
@@ -762,9 +750,50 @@ export default function SettingsSecurity({
           unavailable, use password unlock, a recovery key, or trusted-device approval.
         </div>
         <div className="help-text" style={{ marginTop: 12 }}>
-          Auth + unlock passkeys: {passkeyPrfEnvelopes.length}. Auth-only passkeys are sign-in
-          methods, not encryption unlock methods.
+          Auth + unlock passkeys: {unlockPasskeys.length}. Auth-only passkeys:{" "}
+          {authOnlyPasskeys.length}. Auth-only passkeys are sign-in methods, not encryption unlock
+          methods.
         </div>
+        {activePasskeys.length > 0 ? (
+          <ul style={{ listStyle: "none", padding: 0, margin: "12px 0 0" }}>
+            {activePasskeys.map((passkey) => (
+              <li
+                key={passkey.credential_id}
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  gap: 12,
+                  alignItems: "center",
+                  padding: "10px 0",
+                  borderTop: "1px solid hsl(var(--border))",
+                }}
+              >
+                <div>
+                  <div style={{ fontWeight: 600 }}>{passkey.label || "Passkey"}</div>
+                  <div className="help-text">
+                    {passkey.can_unlock ? "Sign-in and encryption unlock" : "Sign-in only"} · Last
+                    used {formatDate(passkey.last_used_at)} · Added {formatDate(passkey.created_at)}
+                  </div>
+                  {passkey.transports && passkey.transports.length > 0 && (
+                    <div className="help-text">{passkey.transports.join(", ")}</div>
+                  )}
+                </div>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => revokePasskey(passkey.credential_id)}
+                  disabled={passkeyRevokeLoading === passkey.credential_id}
+                >
+                  Revoke
+                </Button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="help-text" style={{ marginTop: 12 }}>
+            No passkeys are registered for this account.
+          </div>
+        )}
         {passkeyMessage && (
           <div className="help-text" style={{ marginTop: 8 }}>
             {passkeyMessage}
@@ -919,16 +948,26 @@ export default function SettingsSecurity({
         <div className="help-text" style={{ marginTop: 8 }}>
           This browser stores only a local key handle; DarkAuth stores the encrypted envelope.
         </div>
+        {sessionData.keyState !== "unlocked" && (
+          <div className="help-text" style={{ marginTop: 8 }}>
+            Unlock encryption keys before trusting this browser.
+          </div>
+        )}
         <div style={{ display: "flex", marginTop: 12 }}>
           <Button
             type="button"
             variant="secondary"
             onClick={trustCurrentDevice}
-            disabled={trustDeviceLoading}
+            disabled={trustDeviceLoading || sessionData.keyState !== "unlocked"}
           >
-            Trust this browser
+            {trustDeviceLoading ? "Trusting browser..." : "Trust this browser"}
           </Button>
         </div>
+        {trustedDeviceMessage && (
+          <div className="help-text" style={{ marginTop: 8 }}>
+            {trustedDeviceMessage}
+          </div>
+        )}
         {activeTrustedDevices.length > 0 ? (
           <ul style={{ listStyle: "none", padding: 0, margin: "12px 0 0" }}>
             {activeTrustedDevices.map((device) => (

--- a/packages/user-ui/src/components/SettingsSecurityView.tsx
+++ b/packages/user-ui/src/components/SettingsSecurityView.tsx
@@ -1,21 +1,42 @@
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { loadUnlockedArk } from "../services/unlockedArk";
 import styles from "./ChangePasswordView.module.css";
+import KeyUnlockPanel from "./KeyUnlockPanel";
 import SettingsSecurity from "./SettingsSecurity";
 import UserLayout from "./UserLayout";
+
+type KeyState = "locked" | "unlocked" | "setup_required";
+
+type SettingsSessionData = {
+  sub: string;
+  name?: string;
+  email?: string;
+  keyState?: KeyState;
+};
+
+function resolveKeyState(sessionData: SettingsSessionData): KeyState {
+  return sessionData.keyState === "unlocked" || loadUnlockedArk(sessionData.sub)
+    ? "unlocked"
+    : sessionData.keyState || "locked";
+}
 
 export default function SettingsSecurityView({
   sessionData,
   onLogout,
 }: {
-  sessionData: {
-    sub: string;
-    name?: string;
-    email?: string;
-    keyState?: "locked" | "unlocked" | "setup_required";
-  };
+  sessionData: SettingsSessionData;
   onLogout: () => void;
 }) {
   const navigate = useNavigate();
+  const [keyState, setKeyState] = useState<KeyState>(() => resolveKeyState(sessionData));
+
+  useEffect(() => {
+    setKeyState(resolveKeyState(sessionData));
+  }, [sessionData]);
+
+  const effectiveSessionData = { ...sessionData, keyState };
+
   return (
     <UserLayout
       userName={sessionData.name}
@@ -28,13 +49,20 @@ export default function SettingsSecurityView({
         <div className={styles.formHeader}>
           <h2>Security Settings</h2>
           <p className={styles.subtitle}>
-            {sessionData.keyState && sessionData.keyState !== "unlocked"
+            {keyState !== "unlocked"
               ? "You are signed in, but encryption keys are locked for zero-knowledge clients."
               : "Manage two-factor authentication, passkeys, recovery keys, and trusted devices"}
           </p>
         </div>
         <div className={styles.formWrapper}>
-          <SettingsSecurity sessionData={sessionData} />
+          {keyState !== "unlocked" ? (
+            <KeyUnlockPanel
+              sub={sessionData.sub}
+              email={sessionData.email}
+              onUnlocked={(session) => setKeyState(session?.keyState || "unlocked")}
+            />
+          ) : null}
+          <SettingsSecurity sessionData={effectiveSessionData} />
         </div>
       </div>
     </UserLayout>

--- a/packages/user-ui/src/components/UserLayout.tsx
+++ b/packages/user-ui/src/components/UserLayout.tsx
@@ -93,7 +93,7 @@ export default function UserLayout({
                         onManageSecurity?.();
                       }}
                     >
-                      Resetup OTP
+                      Passkeys & Security
                     </button>
                     <button
                       type="button"

--- a/packages/user-ui/src/services/api.ts
+++ b/packages/user-ui/src/services/api.ts
@@ -1004,6 +1004,22 @@ class ApiService {
     return data.envelope;
   }
 
+  async getWebAuthnCredentials(): Promise<WebAuthnCredentialResponse[]> {
+    const data = await this.request<
+      { credentials: WebAuthnCredentialResponse[] } | WebAuthnCredentialResponse[]
+    >("/webauthn/credentials");
+    return Array.isArray(data) ? data : data.credentials;
+  }
+
+  async revokeWebAuthnCredential(credentialId: string): Promise<WebAuthnCredentialResponse> {
+    const data = await this.request<
+      { credential: WebAuthnCredentialResponse } | WebAuthnCredentialResponse
+    >(`/webauthn/credentials/${encodeURIComponent(credentialId)}/revoke`, {
+      method: "POST",
+    });
+    return "credential" in data ? data.credential : data;
+  }
+
   async getFederationRoute(email: string): Promise<FederationConnectionRoute | null> {
     const query = new URLSearchParams({ email });
     const data = await this.request<{ connection: FederationConnectionRoute | null }>(

--- a/specs/USER_KEY_MANAGEMENT.md
+++ b/specs/USER_KEY_MANAGEMENT.md
@@ -917,6 +917,7 @@ A checked item means the repository contains an implemented, wired code path for
 - [x] Add a true offline recovery-key unlock path during authorization.
 - [x] Remove or rework the old-password recovery flow so email/password reset cannot be treated as equivalent to an offline recovery key.
 - [x] Make authenticated-but-key-locked state obvious outside the authorization screen, including the dashboard and settings surfaces.
+- [x] Add dashboard/settings password unlock for authenticated key-locked sessions.
 - [ ] Enforce SCIM/SSO unlock-method policy in the user UI.
 - [ ] Add user-visible connected identity and enterprise SSO management.
 - [ ] Add user-visible password sign-in method management separate from encryption unlock methods.
@@ -951,8 +952,8 @@ A checked item means the repository contains an implemented, wired code path for
 - [x] Add browser compatibility messaging in user settings.
 - [x] Add passkey registration UI.
 - [x] Add passkey login UI.
-- [ ] Add passkey management UI listing registered credentials.
-- [ ] Add passkey revoke UI and API.
+- [x] Add passkey management UI listing registered credentials.
+- [x] Add passkey revoke UI and API.
 - [x] Add PRF envelope setup UI that performs the WebAuthn PRF ceremony and wraps the ARK.
 - [x] Replace the disabled `Passkey setup unavailable` settings control with a working setup flow.
 - [x] Update server-side session state to unlocked after successful passkey PRF unlock, or add an authorization finalize path that accepts the verified PRF unlock result.
@@ -1057,7 +1058,7 @@ A checked item means the repository contains an implemented, wired code path for
 - [x] Ensure SSO login to ZK clients prompts for a separate key unlock or setup journey.
 - [ ] Ensure account linking never trusts an unverified upstream email alone. Default and admin-UI-created paths now reject unverified upstream email, but a metadata escape hatch still exists in the model/API.
 - [x] Enforce all SCIM enterprise sign-in and unlock-method policies.
-- [ ] Label actual registered passkeys as auth-only versus auth-and-unlock in user UI.
+- [x] Label actual registered passkeys as auth-only versus auth-and-unlock in user UI.
 
 ### Audit And Abuse Prevention
 


### PR DESCRIPTION
## Summary

- Add user WebAuthn credential listing and revoke endpoints, including PRF envelope revocation and OpenAPI/router wiring.
- Add dashboard/settings password unlock for authenticated key-locked sessions using local key unwrap, plus passkey list/revoke UI with auth-only versus auth-and-unlock labels.
- Add guardrail coverage for key delivery metadata and trusted-device approval AAD replay, and update the user key management checklist only for implemented items.

## Verification

- `git diff --check`
- `npm test -w @DarkAuth/user-ui`
- `npm --workspace @DarkAuth/api exec -- node --env-file-if-exists=../../.env --test src/controllers/user/session.test.ts src/models/trustedDevices.test.ts src/controllers/user/authorizeFinalizeKeyDelivery.test.ts src/controllers/user/webauthn.test.ts src/models/webauthn.test.ts`
- `npm run tidy`
- `npm run build`

## Notes

- Build reports existing Vite large-chunk warnings only.
- Trusted-device approval binding to client/state/verification-code remains unchecked in the spec and should be handled separately.
