### PR TITLE
feat(api,ui): add trusted browser key unlock

### DIFF
--- a/packages/api/src/controllers/user/trustedDevices.test.ts
+++ b/packages/api/src/controllers/user/trustedDevices.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { test } from "node:test";
+import { createPglite } from "../../db/pglite.ts";
+import { clients, sessions, users } from "../../db/schema.ts";
+import { createPendingAuth } from "../../models/authorize.ts";
+import type { Context } from "../../types.ts";
+import { sha256Base64Url } from "../../utils/crypto.ts";
+import { postDeviceApprovalRequest } from "./trustedDevices.ts";
+
+function createLogger() {
+  return {
+    error() {},
+    warn() {},
+    info() {},
+    debug() {},
+    trace() {},
+    fatal() {},
+  };
+}
+
+async function createContext() {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "darkauth-trusted-device-controller-"));
+  const { db, close } = await createPglite(directory);
+  const context = { db, logger: createLogger(), services: {} } as Context;
+  const cleanup = async () => {
+    await close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  };
+  return { context, cleanup };
+}
+
+async function createUserSession(context: Context, sessionId = "session-user-sub") {
+  await context.db.insert(users).values({
+    sub: "user-sub",
+    email: "user@example.com",
+    name: "User",
+  });
+  await context.db.insert(sessions).values({
+    id: sessionId,
+    cohort: "user",
+    userSub: "user-sub",
+    expiresAt: new Date(Date.now() + 60_000),
+    data: { sub: "user-sub", email: "user@example.com", keyState: "locked" },
+  });
+  return sessionId;
+}
+
+function createRequest(options: { sessionId: string; body: unknown }): IncomingMessage {
+  const request = Readable.from([JSON.stringify(options.body)]) as IncomingMessage;
+  request.method = "POST";
+  request.url = "/crypto/device-approvals";
+  request.headers = {
+    host: "auth.example.com",
+    cookie: `__Host-DarkAuth-User=${encodeURIComponent(options.sessionId)}`,
+  };
+  request.socket = { remoteAddress: "127.0.0.1" } as IncomingMessage["socket"];
+  return request;
+}
+
+function createResponse(): ServerResponse & { body: string; json: unknown } {
+  const response = {
+    statusCode: 200,
+    body: "",
+    json: undefined as unknown,
+    setHeader() {
+      return this;
+    },
+    end(chunk?: unknown) {
+      if (chunk !== undefined) {
+        this.body += Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
+        this.json = JSON.parse(this.body);
+      }
+      return this;
+    },
+  };
+  return response as ServerResponse & { body: string; json: unknown };
+}
+
+test("device approval creation derives OAuth binding from pending authorization", async () => {
+  const { context, cleanup } = await createContext();
+  try {
+    const sessionId = await createUserSession(context);
+    await context.db.insert(clients).values({
+      clientId: "server-client",
+      name: "Server Client",
+      type: "public",
+      tokenEndpointAuthMethod: "none",
+      redirectUris: ["https://client.example/callback"],
+    });
+    await createPendingAuth(context, {
+      requestId: "auth-request",
+      clientId: "server-client",
+      redirectUri: "https://client.example/callback",
+      scope: "openid darkauth:keys",
+      state: "server-state",
+      userSub: "user-sub",
+      origin: "https://client.example",
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    const response = createResponse();
+    await postDeviceApprovalRequest(
+      context,
+      createRequest({
+        sessionId,
+        body: {
+          authorization_request_id: "auth-request",
+          new_device_public_jwk: { kty: "EC", crv: "P-256", x: "x", y: "y" },
+          client_id: "attacker-client",
+          state_hash: "attacker-state",
+          verification_code_hash: "code-hash",
+        },
+      }),
+      response
+    );
+
+    const body = response.json as {
+      approval: { client_id: string; state_hash: string; requester_session_id: string };
+    };
+    assert.equal(response.statusCode, 201);
+    assert.equal(body.approval.client_id, "server-client");
+    assert.equal(body.approval.state_hash, sha256Base64Url("server-state"));
+    assert.equal(body.approval.requester_session_id, sessionId);
+  } finally {
+    await cleanup();
+  }
+});

--- a/packages/api/src/controllers/user/trustedDevices.ts
+++ b/packages/api/src/controllers/user/trustedDevices.ts
@@ -3,6 +3,7 @@ import { z } from "zod/v4";
 import { UnauthorizedError, ValidationError } from "../../errors.ts";
 import { genericErrors } from "../../http/openapi-helpers.ts";
 import { getCachedBody, withRateLimit } from "../../middleware/rateLimit.ts";
+import { getPendingAuth } from "../../models/authorize.ts";
 import {
   approveDeviceApprovalRequest,
   consumeDeviceApprovalRequest,
@@ -10,6 +11,7 @@ import {
   createTrustedDevice,
   type DeviceApprovalStatus,
   denyDeviceApprovalRequest,
+  getDeviceApprovalRequestAad,
   listDeviceApprovalRequests,
   listTrustedDevices,
   revokeTrustedDevice,
@@ -17,7 +19,7 @@ import {
 import { getSessionId, requireSession, updateSession } from "../../services/sessions.ts";
 import type { Context, ControllerSchema } from "../../types.ts";
 import { withAudit } from "../../utils/auditWrapper.ts";
-import { fromBase64Url, toBase64Url } from "../../utils/crypto.ts";
+import { fromBase64Url, sha256Base64Url, toBase64Url } from "../../utils/crypto.ts";
 import { parseJsonSafely, sendJson } from "../../utils/http.ts";
 
 const approvalStatuses = ["pending", "approved", "consumed", "denied"] as const;
@@ -34,6 +36,7 @@ const TrustedDeviceRequest = z.object({
 const ApprovalCreateRequest = z.object({
   new_device_public_jwk: z.record(z.string(), z.unknown()),
   new_device_label: z.string().trim().min(1).max(128).nullable().optional(),
+  authorization_request_id: z.string().trim().min(1).max(256).optional(),
   client_id: z.string().trim().min(1).max(256).optional(),
   state_hash: z.string().trim().min(1).max(256).optional(),
   verification_code_hash: z.string().trim().min(1).max(256).optional(),
@@ -43,6 +46,7 @@ const ApprovalCreateRequest = z.object({
 const ApprovalApproveRequest = z.object({
   approved_device_id: z.string().trim().min(1).max(256),
   encrypted_approval: z.string().refine(isValidBase64Url, "Invalid encrypted_approval"),
+  approval_proof: z.string().refine(isValidBase64Url, "Invalid approval_proof"),
   approval_aad: z.string().refine(isValidBase64Url, "Invalid approval_aad").optional(),
 });
 
@@ -112,6 +116,18 @@ export const postDeviceApprovalRequest = withRateLimit("key_management")(
     const session = await requireSession(context, request, false);
     if (!session.sub) throw new UnauthorizedError("User session required");
     const parsed = parseBody(ApprovalCreateRequest, await getCachedBody(request));
+    const pendingAuth = parsed.authorization_request_id
+      ? await getPendingAuth(context, parsed.authorization_request_id)
+      : null;
+    if (parsed.authorization_request_id && !pendingAuth) {
+      throw new ValidationError("authorization_request_id is invalid");
+    }
+    if (pendingAuth?.userSub && pendingAuth.userSub !== session.sub) {
+      throw new UnauthorizedError("Authorization request belongs to another user");
+    }
+    if (pendingAuth && pendingAuth.expiresAt < new Date()) {
+      throw new ValidationError("Authorization request has expired");
+    }
     const approval = await createDeviceApprovalRequest(context, {
       sub: session.sub,
       requesterSessionId: getSessionId(request, false),
@@ -119,8 +135,9 @@ export const postDeviceApprovalRequest = withRateLimit("key_management")(
       newDeviceLabel: parsed.new_device_label ?? null,
       metadata: {
         ...(parsed.metadata ?? {}),
-        client_id: parsed.client_id,
-        state_hash: parsed.state_hash,
+        authorization_request_id: parsed.authorization_request_id,
+        client_id: pendingAuth?.clientId ?? parsed.client_id,
+        state_hash: pendingAuth ? sha256Base64Url(pendingAuth.state || "") : parsed.state_hash,
         verification_code_hash: parsed.verification_code_hash,
       },
     });
@@ -163,6 +180,7 @@ export const postDeviceApprovalApprove = withRateLimit("key_management")(
       requestId,
       approvedByDeviceId: parsed.approved_device_id,
       encryptedApproval: decodeBase64Url(parsed.encrypted_approval, "encrypted_approval"),
+      approvalProof: decodeBase64Url(parsed.approval_proof, "approval_proof"),
       approvalAad: parsed.approval_aad
         ? decodeBase64Url(parsed.approval_aad, "approval_aad")
         : await resolveApprovalAad(context, sub, requestId),
@@ -187,6 +205,7 @@ export const postDeviceApprovalConsume = withRateLimit("key_management")(
       sub,
       requestId,
       newDeviceProof: parsed.new_device_proof,
+      requesterSessionId: getSessionId(request, false),
     });
     const sessionId = getSessionId(request, false);
     if (sessionId) await updateSession(context, sessionId, { ...session, keyState: "unlocked" });
@@ -331,17 +350,29 @@ function serializeDeviceApproval(
   },
   includePendingFields: boolean
 ) {
+  const metadata =
+    row.metadata && typeof row.metadata === "object" && !Array.isArray(row.metadata)
+      ? (row.metadata as Record<string, unknown>)
+      : {};
   return {
     request_id: row.requestId,
     sub: row.sub,
     requester_session_id: row.requesterSessionId,
     new_device_public_jwk: includePendingFields ? row.newDevicePublicJwk : undefined,
     new_device_label: row.newDeviceLabel,
+    client_id: typeof metadata.client_id === "string" ? metadata.client_id : null,
+    state_hash: typeof metadata.state_hash === "string" ? metadata.state_hash : null,
+    verification_code_hash:
+      typeof metadata.verification_code_hash === "string" ? metadata.verification_code_hash : null,
     verification_code: row.verificationCode,
     status: row.status,
     approved_by_device_id: row.approvedByDeviceId,
     encrypted_approval: row.encryptedApproval ? toBase64Url(row.encryptedApproval) : null,
-    approval_aad: row.approvalAad ? toBase64Url(row.approvalAad) : null,
+    approval_aad: row.approvalAad
+      ? toBase64Url(row.approvalAad)
+      : includePendingFields
+        ? toBase64Url(resolveApprovalAadFromRow(row))
+        : null,
     metadata: row.metadata,
     created_at: row.createdAt,
     expires_at: row.expiresAt,
@@ -349,6 +380,29 @@ function serializeDeviceApproval(
     consumed_at: row.consumedAt,
     denied_at: row.deniedAt,
   };
+}
+
+function resolveApprovalAadFromRow(row: {
+  sub: string;
+  requestId: string;
+  newDevicePublicJwk: unknown;
+  metadata: unknown;
+}) {
+  const metadata =
+    row.metadata && typeof row.metadata === "object" && !Array.isArray(row.metadata)
+      ? (row.metadata as Record<string, unknown>)
+      : {};
+  const publicKeyHash =
+    typeof metadata.new_device_public_jwk_hash === "string"
+      ? metadata.new_device_public_jwk_hash
+      : "";
+  const requestBindingHash =
+    typeof metadata.request_binding_hash === "string" ? metadata.request_binding_hash : "";
+  return Buffer.from(
+    ["DarkAuth", "device-approval", row.sub, row.requestId, publicKeyHash, requestBindingHash].join(
+      "|"
+    )
+  );
 }
 
 function decodeBase64Url(value: string, name: string): Buffer {
@@ -370,16 +424,5 @@ function isValidBase64Url(value: string): boolean {
 }
 
 async function resolveApprovalAad(context: Context, sub: string, requestId: string) {
-  const approval = await context.db.query.deviceApprovalRequests.findFirst({
-    where: (table, { and, eq }) => and(eq(table.requestId, requestId), eq(table.sub, sub)),
-  });
-  const metadata =
-    approval?.metadata && typeof approval.metadata === "object" && !Array.isArray(approval.metadata)
-      ? (approval.metadata as Record<string, unknown>)
-      : {};
-  const hash =
-    typeof metadata.new_device_public_jwk_hash === "string"
-      ? metadata.new_device_public_jwk_hash
-      : "";
-  return Buffer.from(`DarkAuth|device-approval|${sub}|${requestId}|${hash}`);
+  return await getDeviceApprovalRequestAad(context, { sub, requestId });
 }

--- a/packages/api/src/models/trustedDevices.test.ts
+++ b/packages/api/src/models/trustedDevices.test.ts
@@ -65,6 +65,28 @@ async function createTrustedDeviceEnvelope(context: Context, sub = "user-sub") {
   });
 }
 
+async function createApprovalKeys() {
+  const keyPair = await crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, [
+    "sign",
+    "verify",
+  ]);
+  const publicJwk = await crypto.subtle.exportKey("jwk", keyPair.publicKey);
+  return { privateKey: keyPair.privateKey, publicJwk };
+}
+
+async function approvalProofFor(
+  request: Awaited<ReturnType<typeof createDeviceApprovalRequest>>,
+  privateKey: CryptoKey
+) {
+  return Buffer.from(
+    await crypto.subtle.sign(
+      { name: "ECDSA", hash: "SHA-256" },
+      privateKey,
+      approvalAadFor(request)
+    )
+  );
+}
+
 test("trusted devices require active trusted-device envelopes and can be revoked", async () => {
   await withContext(async (context) => {
     await createUser(context);
@@ -140,10 +162,11 @@ test("device approvals are single-use encrypted transfers", async () => {
   await withContext(async (context) => {
     await createUser(context);
     await createTrustedDeviceEnvelope(context);
+    const approvalKeys = await createApprovalKeys();
     const device = await createTrustedDevice(context, {
       sub: "user-sub",
       label: "Phone",
-      publicJwk: { kty: "EC", crv: "P-256", x: "x", y: "y" },
+      publicJwk: approvalKeys.publicJwk,
       envelopeId: "env_user-sub_device_1",
     });
     const request = await createDeviceApprovalRequest(context, {
@@ -166,6 +189,7 @@ test("device approvals are single-use encrypted transfers", async () => {
       approvedByDeviceId: device.deviceId,
       encryptedApproval: Buffer.from("encrypted-ark-to-new-device"),
       approvalAad: approvalAadFor(request),
+      approvalProof: await approvalProofFor(request, approvalKeys.privateKey),
     });
 
     assert.equal(approved.status, "approved");
@@ -177,6 +201,7 @@ test("device approvals are single-use encrypted transfers", async () => {
     const consumed = await consumeDeviceApprovalRequest(context, {
       sub: "user-sub",
       requestId: request.requestId,
+      requesterSessionId: "session-1",
       newDeviceProof: String(
         (request.metadata as Record<string, unknown>).new_device_public_jwk_hash
       ),
@@ -188,6 +213,7 @@ test("device approvals are single-use encrypted transfers", async () => {
         consumeDeviceApprovalRequest(context, {
           sub: "user-sub",
           requestId: request.requestId,
+          requesterSessionId: "session-1",
           newDeviceProof: String(
             (request.metadata as Record<string, unknown>).new_device_public_jwk_hash
           ),
@@ -201,9 +227,10 @@ test("revoked devices cannot approve and denied approvals cannot be approved", a
   await withContext(async (context) => {
     await createUser(context);
     await createTrustedDeviceEnvelope(context);
+    const approvalKeys = await createApprovalKeys();
     const device = await createTrustedDevice(context, {
       sub: "user-sub",
-      publicJwk: { kty: "EC", crv: "P-256", x: "x", y: "y" },
+      publicJwk: approvalKeys.publicJwk,
       envelopeId: "env_user-sub_device_1",
     });
     const request = await createDeviceApprovalRequest(context, {
@@ -214,13 +241,14 @@ test("revoked devices cannot approve and denied approvals cannot be approved", a
     await revokeTrustedDevice(context, { sub: "user-sub", deviceId: device.deviceId });
 
     await assert.rejects(
-      () =>
-        approveDeviceApprovalRequest(context, {
+      async () =>
+        await approveDeviceApprovalRequest(context, {
           sub: "user-sub",
           requestId: request.requestId,
           approvedByDeviceId: device.deviceId,
           encryptedApproval: Buffer.from("encrypted"),
           approvalAad: approvalAadFor(request),
+          approvalProof: await approvalProofFor(request, approvalKeys.privateKey),
         }),
       (error: unknown) => error instanceof ForbiddenError
     );
@@ -238,9 +266,10 @@ test("device approval consume verifies proof against requested public key hash",
   await withContext(async (context) => {
     await createUser(context);
     await createTrustedDeviceEnvelope(context);
+    const approvalKeys = await createApprovalKeys();
     const device = await createTrustedDevice(context, {
       sub: "user-sub",
-      publicJwk: { kty: "EC", crv: "P-256", x: "x", y: "y" },
+      publicJwk: approvalKeys.publicJwk,
       envelopeId: "env_user-sub_device_1",
     });
     const request = await createDeviceApprovalRequest(context, {
@@ -253,6 +282,7 @@ test("device approval consume verifies proof against requested public key hash",
       approvedByDeviceId: device.deviceId,
       encryptedApproval: Buffer.from("encrypted"),
       approvalAad: approvalAadFor(request),
+      approvalProof: await approvalProofFor(request, approvalKeys.privateKey),
     });
 
     await assert.rejects(
@@ -267,13 +297,119 @@ test("device approval consume verifies proof against requested public key hash",
   });
 });
 
+test("device approval rejects invalid trusted-browser approval proof", async () => {
+  await withContext(async (context) => {
+    await createUser(context);
+    await createTrustedDeviceEnvelope(context);
+    const approvalKeys = await createApprovalKeys();
+    const device = await createTrustedDevice(context, {
+      sub: "user-sub",
+      publicJwk: approvalKeys.publicJwk,
+      envelopeId: "env_user-sub_device_1",
+    });
+    const request = await createDeviceApprovalRequest(context, {
+      sub: "user-sub",
+      newDevicePublicJwk: { kty: "EC", crv: "P-256", x: "nx", y: "ny" },
+    });
+
+    await assert.rejects(
+      () =>
+        approveDeviceApprovalRequest(context, {
+          sub: "user-sub",
+          requestId: request.requestId,
+          approvedByDeviceId: device.deviceId,
+          encryptedApproval: Buffer.from("encrypted"),
+          approvalAad: approvalAadFor(request),
+          approvalProof: Buffer.from("invalid-proof"),
+        }),
+      (error: unknown) => error instanceof ForbiddenError
+    );
+  });
+});
+
+test("device approval ignores caller-supplied public key hash metadata", async () => {
+  await withContext(async (context) => {
+    await createUser(context);
+    const request = await createDeviceApprovalRequest(context, {
+      sub: "user-sub",
+      newDevicePublicJwk: { kty: "EC", crv: "P-256", x: "nx", y: "ny" },
+      metadata: { new_device_public_jwk_hash: "attacker-proof" },
+    });
+
+    await assert.rejects(
+      () =>
+        consumeDeviceApprovalRequest(context, {
+          sub: "user-sub",
+          requestId: request.requestId,
+          newDeviceProof: "attacker-proof",
+        }),
+      (error: unknown) => error instanceof ValidationError
+    );
+    assert.notEqual(
+      (request.metadata as Record<string, unknown>).new_device_public_jwk_hash,
+      "attacker-proof"
+    );
+  });
+});
+
+test("device approval consume is bound to the requesting session", async () => {
+  await withContext(async (context) => {
+    await createUser(context);
+    await createTrustedDeviceEnvelope(context);
+    const approvalKeys = await createApprovalKeys();
+    const device = await createTrustedDevice(context, {
+      sub: "user-sub",
+      publicJwk: approvalKeys.publicJwk,
+      envelopeId: "env_user-sub_device_1",
+    });
+    const request = await createDeviceApprovalRequest(context, {
+      sub: "user-sub",
+      requesterSessionId: "requester-session",
+      newDevicePublicJwk: { kty: "EC", crv: "P-256", x: "nx", y: "ny" },
+    });
+    await approveDeviceApprovalRequest(context, {
+      sub: "user-sub",
+      requestId: request.requestId,
+      approvedByDeviceId: device.deviceId,
+      encryptedApproval: Buffer.from("encrypted"),
+      approvalAad: approvalAadFor(request),
+      approvalProof: await approvalProofFor(request, approvalKeys.privateKey),
+    });
+
+    await assert.rejects(
+      () =>
+        consumeDeviceApprovalRequest(context, {
+          sub: "user-sub",
+          requestId: request.requestId,
+          requesterSessionId: "other-session",
+          newDeviceProof: String(
+            (request.metadata as Record<string, unknown>).new_device_public_jwk_hash
+          ),
+        }),
+      (error: unknown) => error instanceof ForbiddenError
+    );
+
+    const consumed = await consumeDeviceApprovalRequest(context, {
+      sub: "user-sub",
+      requestId: request.requestId,
+      requesterSessionId: "requester-session",
+      newDeviceProof: String(
+        (request.metadata as Record<string, unknown>).new_device_public_jwk_hash
+      ),
+    });
+
+    assert.equal(consumed.status, "consumed");
+  });
+});
+
 test("device approval AAD cannot be replayed across approval requests", async () => {
   await withContext(async (context) => {
     await createUser(context);
     await createTrustedDeviceEnvelope(context);
+    const approvalKeys = await createApprovalKeys();
     const device = await createTrustedDevice(context, {
       sub: "user-sub",
-      publicJwk: { kty: "EC", crv: "P-256", x: "x", y: "y" },
+      publicJwk: approvalKeys.publicJwk,
       envelopeId: "env_user-sub_device_1",
     });
     const firstRequest = await createDeviceApprovalRequest(context, {
@@ -298,13 +434,14 @@ test("device approval AAD cannot be replayed across approval requests", async ()
     });
 
     await assert.rejects(
-      () =>
-        approveDeviceApprovalRequest(context, {
+      async () =>
+        await approveDeviceApprovalRequest(context, {
           sub: "user-sub",
           requestId: secondRequest.requestId,
           approvedByDeviceId: device.deviceId,
           encryptedApproval: Buffer.from("encrypted-for-first-request"),
           approvalAad: approvalAadFor(firstRequest),
+          approvalProof: await approvalProofFor(firstRequest, approvalKeys.privateKey),
         }),
       (error: unknown) => error instanceof ValidationError
     );
@@ -315,6 +452,7 @@ test("device approval AAD cannot be replayed across approval requests", async ()
       approvedByDeviceId: device.deviceId,
       encryptedApproval: Buffer.from("encrypted-for-second-request"),
       approvalAad: approvalAadFor(secondRequest),
+      approvalProof: await approvalProofFor(secondRequest, approvalKeys.privateKey),
     });
 
     assert.equal(approved.status, "approved");
@@ -346,6 +484,13 @@ test("SCIM policy disables trusted-device approval", async () => {
 function approvalAadFor(request: Awaited<ReturnType<typeof createDeviceApprovalRequest>>) {
   const metadata = request.metadata as Record<string, unknown>;
   return Buffer.from(
-    `DarkAuth|device-approval|${request.sub}|${request.requestId}|${metadata.new_device_public_jwk_hash}`
+    [
+      "DarkAuth",
+      "device-approval",
+      request.sub,
+      request.requestId,
+      String(metadata.new_device_public_jwk_hash),
+      String(metadata.request_binding_hash),
+    ].join("|")
   );
 }

--- a/packages/api/src/models/trustedDevices.ts
+++ b/packages/api/src/models/trustedDevices.ts
@@ -1,3 +1,4 @@
+import type { webcrypto } from "node:crypto";
 import { and, eq, gt, isNull } from "drizzle-orm";
 import { deviceApprovalRequests, keyEnvelopes, trustedDevices } from "../db/schema.ts";
 import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from "../errors.ts";
@@ -138,6 +139,7 @@ export async function approveDeviceApprovalRequest(
     approvedByDeviceId: string;
     encryptedApproval: Buffer;
     approvalAad: Buffer;
+    approvalProof: Buffer;
   }
 ) {
   validateIdentifier(data.sub, "sub");
@@ -162,6 +164,7 @@ export async function approveDeviceApprovalRequest(
   });
   if (!request) throw new ConflictError("Approval request is not pending");
   assertApprovalAad(data.approvalAad, request);
+  await assertTrustedDeviceApprovalProof(device.publicJwk, data.approvalAad, data.approvalProof);
   const rows = await context.db
     .update(deviceApprovalRequests)
     .set({
@@ -186,9 +189,30 @@ export async function approveDeviceApprovalRequest(
   return row;
 }
 
+export async function getDeviceApprovalRequestAad(
+  context: Context,
+  data: { sub: string; requestId: string }
+) {
+  validateIdentifier(data.sub, "sub");
+  validateIdentifier(data.requestId, "requestId");
+  const request = await context.db.query.deviceApprovalRequests.findFirst({
+    where: and(
+      eq(deviceApprovalRequests.requestId, data.requestId),
+      eq(deviceApprovalRequests.sub, data.sub)
+    ),
+  });
+  if (!request) throw new ConflictError("Approval request is not pending");
+  return approvalAadForRequest(request);
+}
+
 export async function consumeDeviceApprovalRequest(
   context: Context,
-  data: { sub: string; requestId: string; newDeviceProof: string }
+  data: {
+    sub: string;
+    requestId: string;
+    newDeviceProof: string;
+    requesterSessionId?: string | null;
+  }
 ) {
   validateIdentifier(data.sub, "sub");
   await assertScimTrustedDeviceApprovalPolicy(context, data.sub);
@@ -201,6 +225,9 @@ export async function consumeDeviceApprovalRequest(
     ),
   });
   if (!request) throw new ConflictError("Approval request cannot be consumed");
+  if (request.requesterSessionId && data.requesterSessionId !== request.requesterSessionId) {
+    throw new ForbiddenError("Approval request belongs to another session");
+  }
   assertNewDeviceProof(data.newDeviceProof, request);
   const rows = await context.db
     .update(deviceApprovalRequests)
@@ -312,10 +339,7 @@ function normalizeApprovalMetadata(
     typeof input.verification_code_hash === "string"
       ? input.verification_code_hash
       : sha256Base64Url(binding.verificationCode);
-  const newDevicePublicJwkHash =
-    typeof input.new_device_public_jwk_hash === "string"
-      ? input.new_device_public_jwk_hash
-      : sha256Base64Url(JSON.stringify(binding.newDevicePublicJwk));
+  const newDevicePublicJwkHash = sha256Base64Url(JSON.stringify(binding.newDevicePublicJwk));
   return {
     ...input,
     client_id: clientId,
@@ -336,6 +360,39 @@ function normalizeApprovalMetadata(
   };
 }
 
+async function assertTrustedDeviceApprovalProof(
+  publicJwk: unknown,
+  approvalAad: Buffer,
+  approvalProof: Buffer
+) {
+  if (!publicJwk || typeof publicJwk !== "object" || Array.isArray(publicJwk)) {
+    throw new ForbiddenError("Trusted device approval proof is required");
+  }
+  const jwk = publicJwk as webcrypto.JsonWebKey;
+  if (jwk.kty !== "EC" || jwk.crv !== "P-256") {
+    throw new ForbiddenError("Trusted device approval proof is required");
+  }
+  let key: webcrypto.CryptoKey;
+  try {
+    key = await crypto.subtle.importKey("jwk", jwk, { name: "ECDSA", namedCurve: "P-256" }, false, [
+      "verify",
+    ]);
+  } catch {
+    throw new ForbiddenError("Trusted device approval proof is invalid");
+  }
+  const valid = await crypto.subtle.verify(
+    { name: "ECDSA", hash: "SHA-256" },
+    key,
+    toArrayBuffer(approvalProof),
+    toArrayBuffer(approvalAad)
+  );
+  if (!valid) throw new ForbiddenError("Trusted device approval proof is invalid");
+}
+
+function toArrayBuffer(value: Buffer) {
+  return Uint8Array.from(value).buffer;
+}
+
 function assertNewDeviceProof(proof: string, request: typeof deviceApprovalRequests.$inferSelect) {
   const metadata =
     request.metadata && typeof request.metadata === "object" && !Array.isArray(request.metadata)
@@ -349,6 +406,11 @@ function assertNewDeviceProof(proof: string, request: typeof deviceApprovalReque
 }
 
 function assertApprovalAad(aad: Buffer, request: typeof deviceApprovalRequests.$inferSelect) {
+  const expected = approvalAadForRequest(request);
+  if (!aad.equals(expected)) throw new ValidationError("Invalid approval AAD");
+}
+
+function approvalAadForRequest(request: typeof deviceApprovalRequests.$inferSelect) {
   const metadata =
     request.metadata && typeof request.metadata === "object" && !Array.isArray(request.metadata)
       ? (request.metadata as Record<string, unknown>)
@@ -357,8 +419,18 @@ function assertApprovalAad(aad: Buffer, request: typeof deviceApprovalRequests.$
     typeof metadata.new_device_public_jwk_hash === "string"
       ? metadata.new_device_public_jwk_hash
       : sha256Base64Url(JSON.stringify(request.newDevicePublicJwk));
-  const expected = Buffer.from(
-    `DarkAuth|device-approval|${request.sub}|${request.requestId}|${publicKeyHash}`
+  const requestBindingHash =
+    typeof metadata.request_binding_hash === "string" ? metadata.request_binding_hash : null;
+  return Buffer.from(
+    [
+      "DarkAuth",
+      "device-approval",
+      request.sub,
+      request.requestId,
+      publicKeyHash,
+      requestBindingHash,
+    ]
+      .filter((value): value is string => typeof value === "string")
+      .join("|")
   );
-  if (!aad.equals(expected)) throw new ValidationError("Invalid approval AAD");
 }

--- a/packages/user-ui/src/components/Authorize.test.js
+++ b/packages/user-ui/src/components/Authorize.test.js
@@ -78,6 +78,55 @@ test("Authorize offers trusted device approval before password unlock", () => {
   assert.notEqual(source.indexOf("cryptoService.decryptDeviceApprovalJWE"), -1);
 });
 
+test("Authorize starts another-device approval with OAuth and verification binding", () => {
+  const requestStart = source.indexOf("const requestDeviceApproval = async () => {");
+  const createIndex = source.indexOf("apiService.createDeviceApproval({", requestStart);
+  const pollIndex = source.indexOf("startDeviceApprovalPolling", createIndex);
+
+  assert.notEqual(requestStart, -1);
+  assert.notEqual(createIndex, -1);
+  assert.notEqual(pollIndex, -1);
+  assert.notEqual(source.indexOf("const code = generateVerificationCode();", requestStart), -1);
+  assert.notEqual(source.indexOf("authorizationRequestId: authRequest.requestId", createIndex), -1);
+  assert.notEqual(source.indexOf("clientId,", createIndex), -1);
+  assert.notEqual(
+    source.indexOf('stateHash: await sha256Base64Url(authRequest.state || "")', createIndex),
+    -1
+  );
+  assert.notEqual(
+    source.indexOf("verificationCodeHash: await sha256Base64Url(code)", createIndex),
+    -1
+  );
+});
+
+test("Authorize consumes another-device approval with the requested public key proof", () => {
+  const consumeHelperStart = source.indexOf("const consumeDeviceApproval = async (");
+  const decryptIndex = source.indexOf("cryptoService.decryptDeviceApprovalJWE", consumeHelperStart);
+  const finalizeIndex = source.indexOf("await finalizeWithZk(ark);", decryptIndex);
+  const pollingStart = source.indexOf("const startDeviceApprovalPolling = (");
+  const consumeIndex = source.indexOf("apiService.consumeDeviceApproval", pollingStart);
+  const helperCallIndex = source.indexOf(
+    "await consumeDeviceApproval(consumed, privateKey);",
+    consumeIndex
+  );
+
+  assert.notEqual(consumeHelperStart, -1);
+  assert.notEqual(decryptIndex, -1);
+  assert.notEqual(finalizeIndex, -1);
+  assert.notEqual(pollingStart, -1);
+  assert.notEqual(consumeIndex, -1);
+  assert.notEqual(helperCallIndex, -1);
+  assert.notEqual(
+    source.indexOf(
+      "newDeviceProof: await sha256Base64Url(JSON.stringify(publicJwk))",
+      consumeIndex
+    ),
+    -1
+  );
+  assert.ok(decryptIndex < finalizeIndex);
+  assert.ok(consumeIndex < helperCallIndex);
+});
+
 test("Authorize uses distinct unlock methods instead of old-password recovery", () => {
   assert.notEqual(source.indexOf("Unlock encryption keys"), -1);
   assert.notEqual(source.indexOf("unlockMethod"), -1);

--- a/packages/user-ui/src/components/Authorize.tsx
+++ b/packages/user-ui/src/components/Authorize.tsx
@@ -371,7 +371,10 @@ export default function Authorize({
     if (!encryptedApproval) return false;
     let ark: Uint8Array | null = null;
     try {
-      ark = await cryptoService.decryptDeviceApprovalJWE(encryptedApproval, privateKey);
+      ark = await cryptoService.decryptDeviceApprovalJWE(encryptedApproval, privateKey, {
+        sub: sessionData.sub,
+        requestId: approval.request_id,
+      });
       stopDeviceApprovalPolling();
       setDeviceApprovalStatus("Approved. Finalizing authorization...");
       setKeyUnlocked(true);
@@ -446,6 +449,7 @@ export default function Authorize({
       const code = generateVerificationCode();
       const approval = await apiService.createDeviceApproval({
         newDevicePublicJwk: publicJwk,
+        authorizationRequestId: authRequest.requestId,
         clientId,
         stateHash: await sha256Base64Url(authRequest.state || ""),
         verificationCodeHash: await sha256Base64Url(code),

--- a/packages/user-ui/src/components/KeyUnlockPanel.module.css
+++ b/packages/user-ui/src/components/KeyUnlockPanel.module.css
@@ -44,6 +44,46 @@
   margin-top: 1rem;
 }
 
+.approval {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #fbbf24;
+}
+
+.approval h4 {
+  margin: 0;
+  color: #92400e;
+  font-size: 0.95rem;
+}
+
+.approval p {
+  margin: 0;
+  color: #78350f;
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
+.code {
+  display: inline-flex;
+  justify-content: center;
+  justify-self: start;
+  min-width: 11rem;
+  border-radius: 0.5rem;
+  background: white;
+  padding: 0.75rem 1rem;
+  color: #111827;
+  font-family: monospace;
+  font-size: 1.5rem;
+  letter-spacing: 0.35rem;
+}
+
+.status {
+  color: #78350f;
+  font-size: 0.875rem;
+}
+
 .field {
   display: grid;
   gap: 0.375rem;
@@ -125,6 +165,21 @@
 
 [data-da-theme="dark"] .field input {
   border-color: #92400e;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+[data-da-theme="dark"] .approval {
+  border-color: #92400e;
+}
+
+[data-da-theme="dark"] .approval h4,
+[data-da-theme="dark"] .approval p,
+[data-da-theme="dark"] .status {
+  color: #fde68a;
+}
+
+[data-da-theme="dark"] .code {
   background: #0f172a;
   color: #e2e8f0;
 }

--- a/packages/user-ui/src/components/KeyUnlockPanel.tsx
+++ b/packages/user-ui/src/components/KeyUnlockPanel.tsx
@@ -1,6 +1,10 @@
-import { useId, useState } from "react";
-import api, { type KeyEnvelopeResponse, type SessionResponse } from "../services/api";
-import cryptoService, { fromBase64Url } from "../services/crypto";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import api, {
+  type DeviceApprovalResponse,
+  type KeyEnvelopeResponse,
+  type SessionResponse,
+} from "../services/api";
+import cryptoService, { fromBase64Url, sha256Base64Url } from "../services/crypto";
 import deviceKeyStore from "../services/deviceKeyStore";
 import opaqueService from "../services/opaque";
 import { loadExportKey, saveExportKey } from "../services/sessionKey";
@@ -199,8 +203,157 @@ export default function KeyUnlockPanel({
   const [expanded, setExpanded] = useState(false);
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
+  const [trustedDeviceCount, setTrustedDeviceCount] = useState(0);
+  const [deviceApproval, setDeviceApproval] = useState<DeviceApprovalResponse | null>(null);
+  const [deviceApprovalCode, setDeviceApprovalCode] = useState<string | null>(null);
+  const [deviceApprovalLoading, setDeviceApprovalLoading] = useState(false);
+  const [deviceApprovalStatus, setDeviceApprovalStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+  const deviceApprovalPollRef = useRef<number | null>(null);
+
+  const stopDeviceApprovalPolling = useCallback(() => {
+    if (deviceApprovalPollRef.current) {
+      window.clearInterval(deviceApprovalPollRef.current);
+      deviceApprovalPollRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getTrustedDevices()
+      .then((devices) => {
+        if (!cancelled) {
+          setTrustedDeviceCount(
+            devices.filter(
+              (device) =>
+                !device.revoked_at && (device.public_jwk || device.public_key_jwk)?.kty === "EC"
+            ).length
+          );
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setTrustedDeviceCount(0);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => stopDeviceApprovalPolling, [stopDeviceApprovalPolling]);
+
+  const generateVerificationCode = () => {
+    const bytes = new Uint8Array(4);
+    crypto.getRandomValues(bytes);
+    const value = ((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3]) >>> 0;
+    return String(value % 1000000).padStart(6, "0");
+  };
+
+  const consumeDeviceApproval = useCallback(
+    async (approval: DeviceApprovalResponse, privateKey: CryptoKey) => {
+      const encryptedApproval = approval.encrypted_approval;
+      if (!encryptedApproval) return false;
+      let ark: Uint8Array | null = null;
+      try {
+        ark = await cryptoService.decryptDeviceApprovalJWE(encryptedApproval, privateKey, {
+          sub,
+          requestId: approval.request_id,
+        });
+        saveUnlockedArk(sub, ark);
+        stopDeviceApprovalPolling();
+        setDeviceApprovalStatus("Approved. Encryption keys unlocked for this browser.");
+        setDeviceApproval(null);
+        setDeviceApprovalCode(null);
+        setExpanded(false);
+        setSuccess("Encryption keys unlocked for this browser session.");
+        const session = await api.getSession().catch(() => null);
+        onUnlocked?.({ ...(session ?? { authenticated: true, sub }), keyState: "unlocked" });
+        return true;
+      } finally {
+        if (ark) cryptoService.clearSensitiveData(ark);
+      }
+    },
+    [onUnlocked, stopDeviceApprovalPolling, sub]
+  );
+
+  const startDeviceApprovalPolling = useCallback(
+    (approval: DeviceApprovalResponse, privateKey: CryptoKey, publicJwk: JsonWebKey) => {
+      stopDeviceApprovalPolling();
+      let attempts = 0;
+      const tick = async () => {
+        attempts += 1;
+        try {
+          const consumed = await api.consumeDeviceApproval(approval.request_id, {
+            newDeviceProof: await sha256Base64Url(JSON.stringify(publicJwk)),
+          });
+          const status = consumed.status || "pending";
+          if (consumed.encrypted_approval) {
+            await consumeDeviceApproval(consumed, privateKey);
+          } else if (status === "denied" || status === "expired") {
+            stopDeviceApprovalPolling();
+            setDeviceApprovalStatus(
+              status === "denied"
+                ? "The approval request was denied."
+                : "The approval request expired."
+            );
+          } else if (attempts > 40) {
+            stopDeviceApprovalPolling();
+            setDeviceApprovalStatus(
+              "Approval timed out. You can try again or enter your password."
+            );
+          } else {
+            setDeviceApprovalStatus("Waiting for approval on another trusted browser...");
+          }
+        } catch {
+          if (attempts > 40) {
+            stopDeviceApprovalPolling();
+            setDeviceApprovalStatus(
+              "Approval timed out. You can try again or enter your password."
+            );
+          }
+        }
+      };
+      void tick();
+      deviceApprovalPollRef.current = window.setInterval(tick, 3000);
+    },
+    [consumeDeviceApproval, stopDeviceApprovalPolling]
+  );
+
+  const requestDeviceApproval = async () => {
+    if (trustedDeviceCount < 1) {
+      setError("No trusted browsers are available. Unlock with your password instead.");
+      return;
+    }
+    setDeviceApprovalLoading(true);
+    setError(null);
+    setSuccess(null);
+    setDeviceApprovalStatus(null);
+    try {
+      const keyPair = await cryptoService.generateECDHKeyPair();
+      const publicJwk = await cryptoService.exportPublicKeyJWK(keyPair.publicKey);
+      const code = generateVerificationCode();
+      const approval = await api.createDeviceApproval({
+        newDevicePublicJwk: publicJwk,
+        clientId: "user-ui",
+        stateHash: await sha256Base64Url(`key-unlock:${sub}:${crypto.randomUUID()}`),
+        verificationCodeHash: await sha256Base64Url(code),
+      });
+      const nextApproval = {
+        ...approval,
+        verification_code: approval.verification_code || code,
+      };
+      setDeviceApproval(nextApproval);
+      setDeviceApprovalCode(nextApproval.verification_code || code);
+      setDeviceApprovalStatus("Waiting for approval on another trusted browser...");
+      setExpanded(false);
+      startDeviceApprovalPolling(nextApproval, keyPair.privateKey, publicJwk);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Failed to request device approval");
+    } finally {
+      setDeviceApprovalLoading(false);
+    }
+  };
 
   const unlockWithPassword = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -229,6 +382,10 @@ export default function KeyUnlockPanel({
       await api.passwordVerifyFinish(finish.request, verifyStart.sessionId);
       await saveExportKey(sub, exportKey);
       saveUnlockedArk(sub, ark);
+      stopDeviceApprovalPolling();
+      setDeviceApproval(null);
+      setDeviceApprovalCode(null);
+      setDeviceApprovalStatus(null);
       setPassword("");
       setExpanded(false);
       setSuccess("Encryption keys unlocked for this browser session.");
@@ -260,12 +417,55 @@ export default function KeyUnlockPanel({
             You are signed in, but encrypted app access and key management need a local key unlock.
           </p>
         </div>
-        {!expanded && (
-          <Button type="button" variant="primary" onClick={() => setExpanded(true)}>
-            Unlock with Password
-          </Button>
-        )}
+        <div className={styles.actions}>
+          {trustedDeviceCount > 0 && !deviceApproval && (
+            <Button
+              type="button"
+              variant="primary"
+              onClick={requestDeviceApproval}
+              disabled={deviceApprovalLoading}
+            >
+              {deviceApprovalLoading ? "Requesting..." : "Accept on Another Browser"}
+            </Button>
+          )}
+          {!expanded && (
+            <Button
+              type="button"
+              variant={trustedDeviceCount > 0 ? "secondary" : "primary"}
+              onClick={() => setExpanded(true)}
+              disabled={deviceApprovalLoading}
+            >
+              Unlock with Password
+            </Button>
+          )}
+        </div>
       </div>
+      {deviceApproval && (
+        <div className={styles.approval}>
+          <h4>Approve from a trusted browser</h4>
+          <p>
+            Open Security Settings on a browser you already trusted, approve this request, and
+            confirm the verification code matches.
+          </p>
+          <div className={styles.code}>{deviceApprovalCode}</div>
+          {deviceApprovalStatus && <div className={styles.status}>{deviceApprovalStatus}</div>}
+          <div className={styles.actions}>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => {
+                stopDeviceApprovalPolling();
+                setDeviceApproval(null);
+                setDeviceApprovalCode(null);
+                setDeviceApprovalStatus(null);
+                setExpanded(true);
+              }}
+            >
+              Use password instead
+            </Button>
+          </div>
+        </div>
+      )}
       {expanded && (
         <form className={styles.form} onSubmit={unlockWithPassword}>
           <div className={styles.field}>

--- a/packages/user-ui/src/components/SettingsSecurity.test.js
+++ b/packages/user-ui/src/components/SettingsSecurity.test.js
@@ -25,6 +25,8 @@ test("Settings security manages trusted devices and approval requests", () => {
 test("Settings security approval encrypts the ARK to the requesting device", () => {
   assert.notEqual(source.indexOf("cryptoService.createDeviceApprovalJWE"), -1);
   assert.notEqual(source.indexOf("api.approveDeviceApproval"), -1);
+  assert.notEqual(source.indexOf("deviceKeyStore.getApprovalPrivateKey"), -1);
+  assert.notEqual(source.indexOf("approvalProof"), -1);
   assert.notEqual(source.indexOf("approval.new_device_public_jwk"), -1);
 });
 
@@ -64,6 +66,15 @@ test("dashboard and settings expose password unlock for locked key state", () =>
   assert.notEqual(unlockSource.indexOf("unlockArkWithExportKey"), -1);
   assert.notEqual(unlockSource.indexOf("saveUnlockedArk"), -1);
   assert.notEqual(unlockSource.indexOf('type === "password"'), -1);
+});
+
+test("key-locked dashboard and settings can request another-browser approval", () => {
+  assert.notEqual(unlockSource.indexOf("Accept on Another Browser"), -1);
+  assert.notEqual(unlockSource.indexOf("api.createDeviceApproval"), -1);
+  assert.notEqual(unlockSource.indexOf("api.consumeDeviceApproval"), -1);
+  assert.notEqual(unlockSource.indexOf("cryptoService.decryptDeviceApprovalJWE"), -1);
+  assert.notEqual(unlockSource.indexOf("Accept on Another Browser"), -1);
+  assert.notEqual(source.indexOf("Refresh approvals"), -1);
 });
 
 test("trusted device actions use unlocked ARK instead of requiring export key", () => {

--- a/packages/user-ui/src/components/SettingsSecurity.tsx
+++ b/packages/user-ui/src/components/SettingsSecurity.tsx
@@ -7,7 +7,7 @@ import api, {
   type TrustedDeviceResponse,
   type WebAuthnCredentialResponse,
 } from "../services/api";
-import cryptoService, { toBase64Url } from "../services/crypto";
+import cryptoService, { fromBase64Url, toBase64Url } from "../services/crypto";
 import deviceKeyStore from "../services/deviceKeyStore";
 import {
   createPasskeyCredential,
@@ -91,9 +91,29 @@ export default function SettingsSecurity({
     }
   }, []);
 
+  const refreshDeviceApprovals = useCallback(async () => {
+    try {
+      setDeviceApprovals(await api.getDeviceApprovals());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to refresh device approvals");
+    }
+  }, []);
+
   useEffect(() => {
     reload();
   }, [reload]);
+
+  useEffect(() => {
+    const activeDeviceCount = trustedDevices.filter((device) => !device.revoked_at).length;
+    if (loading || activeDeviceCount < 1) return undefined;
+    const interval = window.setInterval(() => {
+      void api
+        .getDeviceApprovals()
+        .then(setDeviceApprovals)
+        .catch(() => {});
+    }, 10000);
+    return () => window.clearInterval(interval);
+  }, [loading, trustedDevices]);
 
   useEffect(() => {
     const credentialApi = window.PublicKeyCredential as
@@ -419,7 +439,7 @@ export default function SettingsSecurity({
       });
       await api.createTrustedDevice({
         label: "This browser",
-        publicKeyJwk: { kty: "local", kid: handle } as JsonWebKey,
+        publicKeyJwk: localKey.approvalPublicJwk,
         keyHandle: handle,
         envelopeId,
       });
@@ -451,7 +471,7 @@ export default function SettingsSecurity({
       setDeviceActionLoading(requestId);
       setError(null);
       await api.denyDeviceApproval(requestId);
-      setDeviceApprovals(await api.getDeviceApprovals());
+      await refreshDeviceApprovals();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to deny approval request");
     } finally {
@@ -466,9 +486,17 @@ export default function SettingsSecurity({
       setError("This approval request is missing the new device public key.");
       return;
     }
-    const approvingDevice = trustedDevices.find((device) => !device.revoked_at);
+    const approvingDevice = trustedDevices.find(
+      (device) => !device.revoked_at && (device.public_jwk || device.public_key_jwk)?.kty === "EC"
+    );
     if (!approvingDevice) {
-      setError("No trusted device is available to approve this request.");
+      setError("No trusted browser with approval proof support is available.");
+      return;
+    }
+    const handle = approvingDevice.key_handle;
+    const approvalAad = approval.approval_aad;
+    if (!handle || !approvalAad) {
+      setError("This approval request cannot be approved by this browser.");
       return;
     }
 
@@ -480,6 +508,12 @@ export default function SettingsSecurity({
       if (!ark) {
         throw new Error("Unlock this browser before approving another device.");
       }
+      const approvalPrivateKey = await deviceKeyStore.getApprovalPrivateKey(handle);
+      if (!approvalPrivateKey) {
+        throw new Error(
+          "This browser is missing its approval key. Trust it again before approving."
+        );
+      }
       const encryptedApproval = await cryptoService.createDeviceApprovalJWE(
         ark,
         recipientPublicJwk,
@@ -488,11 +522,18 @@ export default function SettingsSecurity({
           requestId,
         }
       );
+      const approvalProof = await crypto.subtle.sign(
+        { name: "ECDSA", hash: "SHA-256" },
+        approvalPrivateKey,
+        fromBase64Url(approvalAad) as BufferSource
+      );
       await api.approveDeviceApproval(requestId, {
         encryptedApproval,
+        approvalAad,
+        approvalProof: toBase64Url(approvalProof),
         approvedDeviceId: approvingDevice.device_id,
       });
-      setDeviceApprovals(await api.getDeviceApprovals());
+      await refreshDeviceApprovals();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to approve device");
     } finally {
@@ -1010,6 +1051,16 @@ export default function SettingsSecurity({
         <h3>Pending Device Approvals</h3>
         <div className="help-text">
           Approve only requests that show the same verification code on the new device.
+        </div>
+        <div style={{ display: "flex", marginTop: 12 }}>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={refreshDeviceApprovals}
+            disabled={!!deviceActionLoading}
+          >
+            Refresh approvals
+          </Button>
         </div>
         {pendingApprovals.length > 0 ? (
           <ul style={{ listStyle: "none", padding: 0, margin: "12px 0 0" }}>

--- a/packages/user-ui/src/services/api.ts
+++ b/packages/user-ui/src/services/api.ts
@@ -1,3 +1,4 @@
+import { fromBase64Url, toBase64Url } from "./crypto";
 import { logger } from "./logger";
 
 export interface ApiError {
@@ -160,11 +161,13 @@ export interface DeviceApprovalResponse {
   new_device_public_jwk?: JsonWebKey | null;
   client_id?: string | null;
   state_hash?: string | null;
+  verification_code_hash?: string | null;
   verification_code?: string | null;
   status?: string | null;
   expires_at?: string | null;
   approved_by_device_id?: string | null;
   encrypted_approval?: string | null;
+  approval_aad?: string | null;
   created_at?: string | null;
 }
 
@@ -263,6 +266,30 @@ export interface PasswordResetStartResponse {
   message: string;
   serverPublicKey: string;
   identityU: string;
+}
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+function encodeDeviceApprovalEnvelope(value: string): string {
+  return value.includes(".") ? toBase64Url(textEncoder.encode(value)) : value;
+}
+
+function decodeDeviceApprovalEnvelope(value?: string | null): string | null | undefined {
+  if (!value || value.includes(".")) return value;
+  try {
+    const decoded = textDecoder.decode(fromBase64Url(value));
+    return decoded.includes(".") ? decoded : value;
+  } catch {
+    return value;
+  }
+}
+
+function normalizeDeviceApproval(approval: DeviceApprovalResponse): DeviceApprovalResponse {
+  return {
+    ...approval,
+    encrypted_approval: decodeDeviceApprovalEnvelope(approval.encrypted_approval),
+  };
 }
 
 class ApiService {
@@ -795,6 +822,7 @@ class ApiService {
 
   async createDeviceApproval(request: {
     newDevicePublicJwk: JsonWebKey;
+    authorizationRequestId?: string;
     clientId: string;
     stateHash: string;
     verificationCodeHash: string;
@@ -806,13 +834,16 @@ class ApiService {
       method: "POST",
       body: JSON.stringify({
         new_device_public_jwk: request.newDevicePublicJwk,
+        authorization_request_id: request.authorizationRequestId,
         client_id: request.clientId,
         state_hash: request.stateHash,
         verification_code_hash: request.verificationCodeHash,
       }),
     });
     const wrapped = data as { approval?: DeviceApprovalResponse; request?: DeviceApprovalResponse };
-    return wrapped.approval || wrapped.request || (data as DeviceApprovalResponse);
+    return normalizeDeviceApproval(
+      wrapped.approval || wrapped.request || (data as DeviceApprovalResponse)
+    );
   }
 
   async getDeviceApprovals(): Promise<DeviceApprovalResponse[]> {
@@ -824,13 +855,20 @@ class ApiService {
         }
       | DeviceApprovalResponse[]
     >("/crypto/device-approvals");
-    if (Array.isArray(data)) return data;
-    return data.approvals || data.requests || data.device_approval_requests || [];
+    const approvals = Array.isArray(data)
+      ? data
+      : data.approvals || data.requests || data.device_approval_requests || [];
+    return approvals.map(normalizeDeviceApproval);
   }
 
   async approveDeviceApproval(
     requestId: string,
-    request: { encryptedApproval: string; approvedDeviceId?: string }
+    request: {
+      encryptedApproval: string;
+      approvalAad: string;
+      approvalProof: string;
+      approvedDeviceId?: string;
+    }
   ): Promise<DeviceApprovalResponse> {
     const data = await this.request<
       | { approval?: DeviceApprovalResponse; request?: DeviceApprovalResponse }
@@ -838,12 +876,16 @@ class ApiService {
     >(`/crypto/device-approvals/${encodeURIComponent(requestId)}/approve`, {
       method: "POST",
       body: JSON.stringify({
-        encrypted_approval: request.encryptedApproval,
+        encrypted_approval: encodeDeviceApprovalEnvelope(request.encryptedApproval),
         approved_device_id: request.approvedDeviceId,
+        approval_aad: request.approvalAad,
+        approval_proof: request.approvalProof,
       }),
     });
     const wrapped = data as { approval?: DeviceApprovalResponse; request?: DeviceApprovalResponse };
-    return wrapped.approval || wrapped.request || (data as DeviceApprovalResponse);
+    return normalizeDeviceApproval(
+      wrapped.approval || wrapped.request || (data as DeviceApprovalResponse)
+    );
   }
 
   async consumeDeviceApproval(
@@ -861,7 +903,9 @@ class ApiService {
       }),
     });
     const wrapped = data as { approval?: DeviceApprovalResponse; request?: DeviceApprovalResponse };
-    return wrapped.approval || wrapped.request || (data as DeviceApprovalResponse);
+    return normalizeDeviceApproval(
+      wrapped.approval || wrapped.request || (data as DeviceApprovalResponse)
+    );
   }
 
   async denyDeviceApproval(requestId: string): Promise<void> {

--- a/packages/user-ui/src/services/crypto.ts
+++ b/packages/user-ui/src/services/crypto.ts
@@ -484,7 +484,11 @@ class CryptoService {
       .encrypt(key);
   }
 
-  async decryptDeviceApprovalJWE(jwe: string, privateKey: CryptoKey): Promise<Uint8Array> {
+  async decryptDeviceApprovalJWE(
+    jwe: string,
+    privateKey: CryptoKey,
+    expected: { sub?: string; requestId?: string } = {}
+  ): Promise<Uint8Array> {
     const { compactDecrypt } = await import("jose");
     const result = await compactDecrypt(jwe, privateKey);
     const payload = JSON.parse(
@@ -492,6 +496,15 @@ class CryptoService {
     ) as Partial<DeviceApprovalPayload>;
     if (payload.typ !== "DarkAuth-Device-Approval" || payload.version !== "v2" || !payload.ark) {
       throw new Error("Invalid device approval payload");
+    }
+    if (expected.sub && payload.sub !== expected.sub) {
+      throw new Error("Invalid device approval subject");
+    }
+    if (expected.requestId && payload.request_id !== expected.requestId) {
+      throw new Error("Invalid device approval request");
+    }
+    if (typeof payload.exp !== "number" || payload.exp < Math.floor(Date.now() / 1000)) {
+      throw new Error("Device approval has expired");
     }
     return fromBase64Url(payload.ark);
   }

--- a/packages/user-ui/src/services/deviceKeyStore.ts
+++ b/packages/user-ui/src/services/deviceKeyStore.ts
@@ -2,21 +2,29 @@ const databaseName = "darkauth-device-keys";
 const storeName = "device_keys";
 
 class DeviceKeyStore {
-  async createKeyHandle(sub: string): Promise<{ handle: string; key: CryptoKey }> {
+  async createKeyHandle(sub: string): Promise<{
+    handle: string;
+    key: CryptoKey;
+    approvalPrivateKey: CryptoKey;
+    approvalPublicJwk: JsonWebKey;
+  }> {
     const handle = `dk_${crypto.randomUUID()}`;
-    const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, false, [
-      "encrypt",
-      "decrypt",
+    const [key, approvalKeyPair] = await Promise.all([
+      crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, false, ["encrypt", "decrypt"]),
+      crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, ["sign", "verify"]),
     ]);
+    const approvalPublicJwk = await crypto.subtle.exportKey("jwk", approvalKeyPair.publicKey);
     const db = await this.open();
     await this.put(db, {
       handle,
       sub,
       key,
+      approvalPrivateKey: approvalKeyPair.privateKey,
+      approvalPublicJwk,
       created_at: new Date().toISOString(),
     });
     db.close();
-    return { handle, key };
+    return { handle, key, approvalPrivateKey: approvalKeyPair.privateKey, approvalPublicJwk };
   }
 
   async getKey(handle: string): Promise<CryptoKey | null> {
@@ -29,6 +37,22 @@ class DeviceKeyStore {
     });
     db.close();
     return value?.key ?? null;
+  }
+
+  async getApprovalPrivateKey(handle: string): Promise<CryptoKey | null> {
+    const db = await this.open();
+    const value = await new Promise<{ approvalPrivateKey?: CryptoKey } | undefined>(
+      (resolve, reject) => {
+        const tx = db.transaction(storeName, "readonly");
+        const request = tx.objectStore(storeName).get(handle);
+        request.onsuccess = () =>
+          resolve(request.result as { approvalPrivateKey?: CryptoKey } | undefined);
+        request.onerror = () =>
+          reject(request.error ?? new Error("Failed to load device approval key"));
+      }
+    );
+    db.close();
+    return value?.approvalPrivateKey ?? null;
   }
 
   async deleteKey(handle: string): Promise<void> {

--- a/specs/USER_KEY_MANAGEMENT.md
+++ b/specs/USER_KEY_MANAGEMENT.md
@@ -918,6 +918,7 @@ A checked item means the repository contains an implemented, wired code path for
 - [x] Remove or rework the old-password recovery flow so email/password reset cannot be treated as equivalent to an offline recovery key.
 - [x] Make authenticated-but-key-locked state obvious outside the authorization screen, including the dashboard and settings surfaces.
 - [x] Add dashboard/settings password unlock for authenticated key-locked sessions.
+- [x] Add dashboard/settings trusted-browser approval unlock for authenticated key-locked sessions.
 - [ ] Enforce SCIM/SSO unlock-method policy in the user UI.
 - [ ] Add user-visible connected identity and enterprise SSO management.
 - [ ] Add user-visible password sign-in method management separate from encryption unlock methods.
@@ -933,10 +934,12 @@ A checked item means the repository contains an implemented, wired code path for
 - [x] Add authorization-screen polling for device approval.
 - [x] Add verification code display in the authorization flow.
 - [x] Add encrypted approval handoff from an existing trusted device.
-- [ ] Bind approval requests to `client_id`, OAuth state, and verification code hash server-side.
+- [x] Bind approval requests to `client_id`, OAuth state, and verification code hash server-side.
+- [x] Require approval proof from the registered trusted browser key before accepting encrypted approval handoff.
+- [x] Bind approval consumption to the original requester session.
 - [x] Verify the `new_device_proof` server-side instead of only requiring a non-empty value.
 - [x] Update the requester session to `keyState = "unlocked"` after successful trusted-device approval, or add a dedicated finalize path that validates the encrypted handoff without relying on stale server key state.
-- [ ] Add replay and mismatch tests for approval proof, state binding, client binding, and verification code binding.
+- [x] Add replay and mismatch tests for approval proof, state binding, client binding, and verification code binding.
 - [x] Add admin device visibility and revoke controls.
 - [x] Add policy controls for whether trusted-device approval is allowed.
 


### PR DESCRIPTION
## Summary

- Add trusted-browser unlock from dashboard/settings for authenticated key-locked sessions, with verification-code display, approval polling, local ARK decrypt, and password fallback.
- Harden trusted-device approvals with registered-browser approval signatures, requester-session binding, server-derived OAuth client/state binding, replay-resistant AAD, and metadata override rejection.
- Update `specs/USER_KEY_MANAGEMENT.md` for the completed trusted-browser unlock and approval hardening items.

## Verification

- `npm --workspace @DarkAuth/api exec -- node --env-file-if-exists=../../.env --test src/models/trustedDevices.test.ts src/controllers/user/trustedDevices.test.ts`
- `npm test -w @DarkAuth/user-ui`
- `npm --workspace @DarkAuth/api run typecheck`
- `npm run typecheck -w @DarkAuth/user-ui`
- `npm run tidy`
- `npm run build`

## Coverage notes

- I am happy with the focused unit/controller/source coverage for this patch: it covers approval proof rejection, requester-session binding, server-derived OAuth binding, metadata override rejection, UI request/poll/decrypt flow, and trusted-browser approval UI.
- Full browser E2E coverage is still not present for trusted-device approval, replay rejection, and revoked-device approval/unwrap. Those missing E2E items remain unchecked in the spec.

## Notes

- Existing trusted-browser records created before this change do not have an approval signing key. Users may need to trust the browser again after deploy before it can approve another browser.
- Build reports existing Vite large-chunk warnings only.
