### PR TITLE
fix(ui): show trusted-device unlock request action

### DIFF
--- a/packages/docs/src/content/docs/users/trusted-devices.mdx
+++ b/packages/docs/src/content/docs/users/trusted-devices.mdx
@@ -7,7 +7,9 @@ Trusted devices let you move encrypted account access to a new browser or device
 
 ## Add a device
 
-Start the device approval flow on the new device with the unlock option for another trusted device, then approve it from an existing trusted device in account security. The approving device creates an encrypted envelope that only the requesting device can consume.
+Start the device approval flow on the new device with **Unlock with Another Device**, then approve it from an existing trusted device in account security. The approving device creates an encrypted envelope that only the requesting device can consume.
+
+The new device shows a verification code while it waits. On the trusted device, open account security, refresh pending device approvals, and approve only the request with the same code.
 
 Approvals expire. If a request is old or unexpected, deny it and start again from a device you control.
 

--- a/packages/user-ui/src/components/KeyUnlockPanel.test.js
+++ b/packages/user-ui/src/components/KeyUnlockPanel.test.js
@@ -21,9 +21,10 @@ test("key unlock panel can request and consume another-browser approval", () => 
 
   assert.notEqual(requestStart, -1);
   assert.notEqual(pollingStart, -1);
-  assert.notEqual(source.indexOf("Accept on Another Browser"), -1);
+  assert.notEqual(source.indexOf("Unlock with Another Device"), -1);
   assert.notEqual(source.indexOf("Approve from a trusted browser"), -1);
   assert.notEqual(source.indexOf("Use password instead"), -1);
+  assert.equal(source.indexOf("trustedDeviceCount"), -1);
   assert.notEqual(source.indexOf("api.createDeviceApproval({", requestStart), -1);
   assert.notEqual(source.indexOf("newDevicePublicJwk: publicJwk", requestStart), -1);
   const keyUnlockStateHash = "stateHash: await sha256Base64Url(`key-unlock:" + "$" + "{sub}:";

--- a/packages/user-ui/src/components/KeyUnlockPanel.tsx
+++ b/packages/user-ui/src/components/KeyUnlockPanel.tsx
@@ -208,7 +208,6 @@ export default function KeyUnlockPanel({
   const [expanded, setExpanded] = useState(false);
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
-  const [trustedDeviceCount, setTrustedDeviceCount] = useState(0);
   const [unlockPolicy, setUnlockPolicy] = useState<UnlockPolicy>(defaultUnlockPolicy);
   const [deviceApproval, setDeviceApproval] = useState<DeviceApprovalResponse | null>(null);
   const [deviceApprovalCode, setDeviceApprovalCode] = useState<string | null>(null);
@@ -234,28 +233,6 @@ export default function KeyUnlockPanel({
       })
       .catch(() => {
         if (!cancelled) setUnlockPolicy(defaultUnlockPolicy);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  useEffect(() => {
-    let cancelled = false;
-    api
-      .getTrustedDevices()
-      .then((devices) => {
-        if (!cancelled) {
-          setTrustedDeviceCount(
-            devices.filter(
-              (device) =>
-                !device.revoked_at && (device.public_jwk || device.public_key_jwk)?.kty === "EC"
-            ).length
-          );
-        }
-      })
-      .catch(() => {
-        if (!cancelled) setTrustedDeviceCount(0);
       });
     return () => {
       cancelled = true;
@@ -344,14 +321,6 @@ export default function KeyUnlockPanel({
   const requestDeviceApproval = async () => {
     if (!isUnlockMethodAllowed(unlockPolicy, "trusted_device")) {
       setError("Trusted-browser approval is disabled by your organization policy.");
-      return;
-    }
-    if (trustedDeviceCount < 1) {
-      setError(
-        passwordAllowed
-          ? "No trusted browsers are available. Unlock with your password instead."
-          : "No trusted browsers are available."
-      );
       return;
     }
     setDeviceApprovalLoading(true);
@@ -454,20 +423,20 @@ export default function KeyUnlockPanel({
           </p>
         </div>
         <div className={styles.actions}>
-          {trustedDeviceAllowed && trustedDeviceCount > 0 && !deviceApproval && (
+          {trustedDeviceAllowed && !deviceApproval && (
             <Button
               type="button"
               variant="primary"
               onClick={requestDeviceApproval}
               disabled={deviceApprovalLoading}
             >
-              {deviceApprovalLoading ? "Requesting..." : "Accept on Another Browser"}
+              {deviceApprovalLoading ? "Requesting..." : "Unlock with Another Device"}
             </Button>
           )}
           {passwordAllowed && !expanded && (
             <Button
               type="button"
-              variant={trustedDeviceAllowed && trustedDeviceCount > 0 ? "secondary" : "primary"}
+              variant={trustedDeviceAllowed ? "secondary" : "primary"}
               onClick={() => setExpanded(true)}
               disabled={deviceApprovalLoading}
             >

--- a/packages/user-ui/src/components/SettingsSecurity.test.js
+++ b/packages/user-ui/src/components/SettingsSecurity.test.js
@@ -70,11 +70,11 @@ test("dashboard and settings expose password unlock for locked key state", () =>
 });
 
 test("key-locked dashboard and settings can request another-browser approval", () => {
-  assert.notEqual(unlockSource.indexOf("Accept on Another Browser"), -1);
+  assert.notEqual(unlockSource.indexOf("Unlock with Another Device"), -1);
   assert.notEqual(unlockSource.indexOf("api.createDeviceApproval"), -1);
   assert.notEqual(unlockSource.indexOf("api.consumeDeviceApproval"), -1);
   assert.notEqual(unlockSource.indexOf("cryptoService.decryptDeviceApprovalJWE"), -1);
-  assert.notEqual(unlockSource.indexOf("Accept on Another Browser"), -1);
+  assert.equal(unlockSource.indexOf("trustedDeviceCount"), -1);
   assert.notEqual(source.indexOf("Refresh approvals"), -1);
 });
 

--- a/specs/USER_KEY_MANAGEMENT.md
+++ b/specs/USER_KEY_MANAGEMENT.md
@@ -655,7 +655,7 @@ Authorization screen behavior:
 
 - If the client is non-ZK, do not show key unlock controls.
 - If the client is ZK and ARK is unlocked, show normal consent/authorization.
-- If the client is ZK and ARK is locked, primary action SHOULD be "Accept on another device" when trusted devices exist, with "Enter password" as fallback.
+- If the client is ZK and ARK is locked, primary action SHOULD be "Unlock with Another Device" when trusted-device approval is allowed, with "Enter password" as fallback.
 - If no unlock method exists, show key setup.
 - If the user is SCIM/SSO managed and policy disallows password envelopes, hide password setup and show allowed methods.
 
@@ -953,7 +953,7 @@ A checked item means the repository contains an implemented, wired code path for
 - [x] Remove or rework the old-password recovery flow so email/password reset cannot be treated as equivalent to an offline recovery key.
 - [x] Make authenticated-but-key-locked state obvious outside the authorization screen, including the dashboard and settings surfaces.
 - [x] Add dashboard/settings password unlock for authenticated key-locked sessions.
-- [x] Add dashboard/settings trusted-browser approval unlock for authenticated key-locked sessions.
+- [x] Add dashboard/settings trusted-browser approval unlock for authenticated key-locked sessions, with the requester action visible whenever trusted-device approval is allowed.
 - [x] Enforce SCIM/SSO unlock-method policy in the user UI.
 - [x] Add user-visible connected identity and enterprise SSO management.
 - [x] Add user-visible password sign-in method management separate from encryption unlock methods.


### PR DESCRIPTION
## Summary
- show the trusted-device unlock request action whenever policy allows it
- remove the locked-browser trusted-device pre-count that hid the request action
- update user UI source tests for the visible button label and removed gate
- clarify the trusted-device unlock flow in the user docs and key-management spec

## Verification
- npm --workspace @DarkAuth/user-ui test -- src/components/KeyUnlockPanel.test.js src/components/SettingsSecurity.test.js
- npm run tidy
- npm run build

## Notes
- The intended flow is: locked browser clicks Unlock with Another Device, trusted browser refreshes Pending Device Approvals and approves the matching verification code.